### PR TITLE
Improved/fix print styles

### DIFF
--- a/app/components/AsciidocBlocks/Document.tsx
+++ b/app/components/AsciidocBlocks/Document.tsx
@@ -100,7 +100,7 @@ const CustomDocument = ({ document }: { document: AdocTypes.Document }) => {
 
             <ul
               id="footnotes"
-              className="col-span-12 col-start-2 800:pr-16 1100:w-[calc(100%-var(--toc-width))] 1200:col-start-3"
+              className="col-span-12 col-start-2 800:pr-16 1100:w-[calc(100%-var(--toc-width))] 1200:col-start-3 print:!col-span-12 print:!col-start-1"
             >
               {footnotes.map((footnote) => (
                 <li
@@ -153,11 +153,11 @@ const CustomDocument = ({ document }: { document: AdocTypes.Document }) => {
           <div
             id="content"
             ref={bodyRef}
-            className="asciidoc-body max-w-full flex-shrink overflow-hidden 800:overflow-visible 800:pr-10 1100:w-[calc(100%-var(--toc-width))] 1200:pr-16"
+            className="asciidoc-body max-w-full flex-shrink overflow-hidden 800:overflow-visible 800:pr-10 1100:w-[calc(100%-var(--toc-width))] 1200:pr-16 print:p-0"
           >
             <Content blocks={blocks} />
           </div>
-          <div className="top-[calc(2rem+(var(--header-height)))] hidden max-h-[calc(100vh-(var(--header-height)+3rem))] w-[var(--toc-width)] flex-shrink-0 flex-grow overflow-auto 1100:sticky 1100:block">
+          <div className="top-[calc(2rem+(var(--header-height)))] hidden max-h-[calc(100vh-(var(--header-height)+3rem))] w-[var(--toc-width)] flex-shrink-0 flex-grow overflow-auto 1100:sticky 1100:block print:hidden">
             <ui.Out />
             <DesktopOutline toc={toc} activeItem={activeItem} />
           </div>

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -229,7 +229,7 @@ export const SmallScreenOutline = ({
     return (
       <Accordion.Root
         type="single"
-        className="fixed bottom-0 left-0 right-0 z-10 mt-4 block max-h-[calc(100vh-var(--header-height)-2rem)] w-full overflow-y-auto border-t border-b bg-default border-secondary 1100:hidden"
+        className="fixed bottom-0 left-0 right-0 z-10 mt-4 block max-h-[calc(100vh-var(--header-height)-2rem)] w-full overflow-y-auto border-t border-b bg-default border-secondary 1100:hidden print:hidden"
         collapsible
       >
         <Accordion.Item value={`small-toc-${title}`}>

--- a/app/components/rfd/AccessWarning.tsx
+++ b/app/components/rfd/AccessWarning.tsx
@@ -28,7 +28,7 @@ const AccessWarning = ({ groups }: { groups: string[] }) => {
 
   return (
     <div className="col-span-12 mt-4  flex 800:col-span-10 800:col-start-2 800:pr-10 1000:col-span-10 1000:col-start-2 1100:col-start-2 1200:col-start-3 1200:pr-16">
-      <div className="items-top flex w-full rounded px-3 py-2 pr-6 text-sans-md text-notice bg-notice-secondary 1100:w-[calc(100%-var(--toc-width))]">
+      <div className="items-top flex w-full rounded px-3 py-2 pr-6 text-sans-md text-notice bg-notice-secondary 1100:w-[calc(100%-var(--toc-width))] print:hidden">
         <Icon name="access" size={16} className="mr-2 flex-shrink-0 text-notice-tertiary" />
         <div>
           This RFD can be accessed by the following groups:

--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -214,12 +214,12 @@ export default function Rfd() {
           </div>
 
           <div className="col-span-12 grid grid-cols-12 items-baseline">
-            <div className="hidden text-sans-lg text-accent-tertiary 800:col-span-1 800:block 1200:col-span-2">
+            <div className="hidden text-sans-lg text-accent-tertiary 800:col-span-1 800:block 1200:col-span-2 print:hidden">
               <span className="hidden 1200:inline">RFD</span> {number}
             </div>
             <div className="col-span-12 flex items-baseline 800:col-span-11 1100:col-span-10">
-              <h1 className="w-full pr-4 text-sans-2xl 600:pr-10 800:text-sans-3xl 1100:w-[calc(100%-var(--toc-width))] 1200:pr-16">
-                {title}
+              <h1 className="w-full pr-4 text-sans-2xl 600:pr-10 800:text-sans-3xl 1100:w-[calc(100%-var(--toc-width))] 1200:pr-16 print:pr-0 print:text-center">
+                <span className="hidden print:block">RFD {number}</span> {title}
               </h1>
               {userIsInternal && (
                 <div className="print:hidden">
@@ -234,11 +234,14 @@ export default function Rfd() {
           </div>
         </Container>
 
-        <div className="border-b border-secondary print:border-0">
-          <PropertyRow label="State" className="hidden capitalize print:block">
+        <div className="border-b border-secondary print:m-auto print:max-w-1200 print:rounded-lg print:border">
+          <PropertyRow
+            label="State"
+            className="hidden capitalize print:block print:border-t-0"
+          >
             {state}
           </PropertyRow>
-          <PropertyRow label="RFD" className="800:hidden">
+          <PropertyRow label="RFD" className="800:hidden print:hidden">
             {number.toString()}
           </PropertyRow>
           {authors.length > 0 && (
@@ -311,12 +314,13 @@ const PropertyRow = ({
 }) => (
   <div
     className={cn(
-      'w-full border-t py-3 border-secondary print:border-0 print:py-2',
+      'w-full border-t py-3 border-secondary print:py-2 print:border-default',
       className,
     )}
   >
     <Container isGrid>
-      <div className="col-span-4 text-mono-sm text-quaternary 800:col-span-1 1200:col-span-2 print:col-span-2">
+      <div className="relative col-span-4 text-mono-sm text-quaternary 800:col-span-1 1200:col-span-2 print:col-span-2 print:text-default">
+        <div className="absolute -top-2 -bottom-2 right-0 w-px bg-[black]" />
         {label}
       </div>
       <div className="col-span-8 text-sans-md text-secondary 800:col-span-9 1200:col-span-8 print:col-span-10">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@ariakit/react": "^0.3.5",
         "@floating-ui/react": "^0.17.0",
         "@meilisearch/instant-meilisearch": "^0.8.2",
-        "@oxide/design-system": "^1.2.13",
+        "@oxide/design-system": "^1.4.0",
         "@oxide/react-asciidoc": "^0.2.3",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^1.0.0",
@@ -3455,9 +3455,9 @@
       "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.13.tgz",
-      "integrity": "sha512-EYFAmyN7Zi56SeVKyoBluDDCvAXHGsSXqyzckkMwXh4N5O5mp2Bitkrg0t/oTgnY2FSlHC0sLbC4uJKWoWJAMQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.4.0.tgz",
+      "integrity": "sha512-s1+BaOQUnl8615dg4d2sZfmS12h5LFbZEdblyPhgmx8M3fMxyEOktUqhhiJYUlbl+ZBPZYeiL9sAqQD8fF5AQA==",
       "dependencies": {
         "@figma-export/output-components-as-svgr": "^4.7.0",
         "@floating-ui/react": "^0.25.1",
@@ -21553,9 +21553,9 @@
       "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
     },
     "@oxide/design-system": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.13.tgz",
-      "integrity": "sha512-EYFAmyN7Zi56SeVKyoBluDDCvAXHGsSXqyzckkMwXh4N5O5mp2Bitkrg0t/oTgnY2FSlHC0sLbC4uJKWoWJAMQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.4.0.tgz",
+      "integrity": "sha512-s1+BaOQUnl8615dg4d2sZfmS12h5LFbZEdblyPhgmx8M3fMxyEOktUqhhiJYUlbl+ZBPZYeiL9sAqQD8fF5AQA==",
       "requires": {
         "@figma-export/output-components-as-svgr": "^4.7.0",
         "@floating-ui/react": "^0.25.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@ariakit/react": "^0.3.5",
     "@floating-ui/react": "^0.17.0",
     "@meilisearch/instant-meilisearch": "^0.8.2",
-    "@oxide/design-system": "^1.2.13",
+    "@oxide/design-system": "^1.4.0",
     "@oxide/react-asciidoc": "^0.2.3",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^1.0.0",


### PR DESCRIPTION
I'm sure more can be done to improve print styles and likely a few edge cases to solve before we stop using the `asciidoctor-pdf` ones, but it's generally looking good.

<img width="889" alt="image" src="https://github.com/oxidecomputer/rfd-site/assets/4020798/1159f989-1c3e-47ad-8600-5d5a8f008716">
