### PR TITLE
Fix decoded examples not working correctly

### DIFF
--- a/app/components/AsciidocBlocks/Listing.tsx
+++ b/app/components/AsciidocBlocks/Listing.tsx
@@ -131,7 +131,7 @@ const Listing = ({ node }: { node: AdocTypes.Block }) => {
                         hljs.highlight(placeholderContent, { language: lang }).value,
                         callouts,
                       )) ||
-                    preparedContent,
+                    placeholderContent,
                 }}
               />
             )}
@@ -148,7 +148,7 @@ const Listing = ({ node }: { node: AdocTypes.Block }) => {
           <pre
             className={cn('highlight !block', nowrap ? 'nowrap' : '')}
             dangerouslySetInnerHTML={{
-              __html: restoreCallouts(preparedContent, callouts),
+              __html: restoreCallouts(placeholderContent, callouts),
             }}
           />
         </div>


### PR DESCRIPTION
RFD 470 had an issue where its text, which looks like HTML was not rendered because it was rendered at HTML instead.

E.g.
```
<disk type="file" device="disk">
    <!-- ... device details ... -->
    <boot order="1"/>
    <address type="pci" domain="0x0000" bus="0x00" slot="0x0a" function="0x0"/>
</disk>
```

Rationale for the fix in the comment, bit of a mind bender. Should be moved into `react-asciidoc` prepared document when thats tackled.

```
// If we are highlighting we want the content to be decoded, since
// highlight.js will want the original content with tags included
// which it will then encode after highlighting.
// Otherwise let's just use the original content which comes from
// asciidoctor.js encoded.
```