### PR TITLE
Fix broken `inline_quoted` following `_`

### DIFF
--- a/app/components/AsciidocBlocks/index.ts
+++ b/app/components/AsciidocBlocks/index.ts
@@ -59,13 +59,21 @@ const convertInlineQuoted = (node: AdocTypes.Inline) => {
     text = renderWithBreaks(text)
   }
 
-  const idAttr = node.getId() ? `id="${node.getId()}"` : ''
-  const classAttr = node.getRole() ? `class="${node.getRole()}"` : ''
+  const id = node.getId()
+  const role = node.getRole()
 
-  if (tag) {
-    return `${chop(open)} ${idAttr} ${classAttr}>${text}${close}`
+  const idAttr = id ? `id="${id}"` : ''
+  const classAttr = role ? `class="${role}"` : ''
+  const attrs = `${idAttr} ${classAttr}`
+
+  if (id || role) {
+    if (tag) {
+      return `${chop(open)} ${attrs}>${text}${close}`
+    } else {
+      return `<span ${attrs}>${open}${text}${close}</span>`
+    }
   } else {
-    return `<span ${idAttr} ${classAttr}>${open}${text}${close}</span>`
+    return `${open}${text}${close}`
   }
 }
 


### PR DESCRIPTION
`convertInlineQuoted` breaks where `_emphasised text_` follows other underscores, e.g. those in a URL.

This technically fixes this issue in this place (RFD 520) by moving closer to the HTML5 renderer implementation. But I believe this is a bug in `asciidoctor` (and the fix is a fluke) since `node.getText()` returns `error_reports_faults_and_diagnosis_engines[Error reports], or _ereports` rather than `ereports`.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/a54d7ca1-8caf-4665-ad27-5d840156c580">
