### PR TITLE
Update scopes to reflect v-api scopes

### DIFF
--- a/app/services/authn.server.ts
+++ b/app/services/authn.server.ts
@@ -24,7 +24,7 @@ import { apiRequest, getRfdApiUrl } from './rfdApi.server'
 export type AuthenticationService = 'github' | 'google' | 'local'
 
 const scope: RfdScope[] = [
-  'group:r',
+  'group:info:r',
   'rfd:content:r',
   'rfd:discussion:r',
   'search',

--- a/app/utils/rfdApi.ts
+++ b/app/utils/rfdApi.ts
@@ -12,8 +12,8 @@ export type RfdScope =
   | 'user:provider:w'
   | 'user:token:r'
   | 'user:token:w'
-  | 'group:r'
-  | 'group:w'
+  | 'group:info:r'
+  | 'group:info:w'
   | 'group:membership:w'
   | 'mapper:r'
   | 'mapper:w'
@@ -22,6 +22,8 @@ export type RfdScope =
   | 'search'
   | 'oauth:client:r'
   | 'oauth:client:w'
+  | 'mlink:client:r'
+  | 'mlink:client:w'
 
 export type RfdApiProvider = 'google' | 'github'
 


### PR DESCRIPTION
`rfd-api` was the initial implementation of what is now `v-api`. Now that the `rfd-api` has been updated to use `v-api` internally we need to update the scopes that are used by the RFD site so they match the updated scopes that `rfd-api`  expects.

I'll merge this at the same time as the updated deployment of the RFD API.

In the future this will be updated to be an NPM package like we do with `turnstile`.