### PR TITLE
Fix callouts and missing link style

### DIFF
--- a/app/components/AsciidocBlocks/Listing.tsx
+++ b/app/components/AsciidocBlocks/Listing.tsx
@@ -102,13 +102,9 @@ const Listing = ({ node }: { node: AdocTypes.Block }) => {
   // which it will then encode after highlighting.
   // Otherwise let's just use the original content which comes from
   // asciidoctor.js encoded.
-  const isSource = node.getStyle() === 'source'
   const lang = attrs.language
-  const hasLang = hljs.getLanguage(lang)
-  const shouldDecode = isSource && (hasLang || lang === 'mermaid')
-  const preparedContent = shouldDecode ? decode(content) || content : content
 
-  const { placeholderContent, callouts } = replaceCallouts(preparedContent)
+  const { placeholderContent, callouts } = replaceCallouts(content)
 
   // Listing blocks of style `source` are source code, should have their syntax
   // highlighted (where we have language support) and be inside both a `pre` and `code` tag
@@ -119,7 +115,7 @@ const Listing = ({ node }: { node: AdocTypes.Block }) => {
         <div className="content">
           <pre className={cn('highlight', nowrap ? ' nowrap' : '')}>
             {lang && lang === 'mermaid' ? (
-              <Mermaid content={preparedContent} />
+              <Mermaid content={decode(content)} />
             ) : (
               <code
                 className={`language-${lang || ''}`}
@@ -131,7 +127,7 @@ const Listing = ({ node }: { node: AdocTypes.Block }) => {
                         hljs.highlight(placeholderContent, { language: lang }).value,
                         callouts,
                       )) ||
-                    placeholderContent,
+                    restoreCallouts(placeholderContent, callouts),
                 }}
               />
             )}

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -91,7 +91,7 @@ button:focus-visible,
 [role='button']:focus-visible,
 input[type='radio']:focus-visible,
 input[type='checkbox']:focus-visible {
-  @apply rounded outline-0 ring ring-2 ring-accent-tertiary;
+  @apply outline-0 ring-2 ring-accent-tertiary;
 }
 
 a:focus,
@@ -104,7 +104,7 @@ input[type='checkbox']:focus {
   outline: 2px solid black;
   outline-offset: -2px;
   box-shadow: none;
-  @apply rounded outline-0 ring ring-2 ring-accent-tertiary;
+  @apply outline-0 ring-2 ring-accent-tertiary;
 }
 
 a:focus:not(:focus-visible),
@@ -147,4 +147,10 @@ input[type='checkbox']:focus:not(:focus-visible) {
 
 #footnotes p code {
   @apply inline-code;
+}
+
+/* todo: include in design-system after upgrade */
+.asciidoc-body a:not(:is(h1, h2, h3, h4, h5, h6) a) {
+  text-decoration-color: rgba(var(--content-accent-tertiary-rgb), 0.8);
+  @apply underline text-accent-secondary;
 }


### PR DESCRIPTION
Link styles also reminds me to finish: https://github.com/oxidecomputer/design-system/pull/83

The callout thing was already working in the new renderer, but its an easy fix here also. (The RFD site is not yet ported over to the new prepared document react asciidoc renderer).

Fixes #85 
Fixes #84 