### PR TITLE
Update tailwind to ts

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,20 +6,17 @@
  * Copyright Oxide Computer Company
  */
 
-// @ts-check
+import plugin from 'tailwindcss/plugin'
 
-/** @type {import('tailwindcss/lib/util/createPlugin').default} */
-// @ts-ignore
-const plugin = require('tailwindcss/plugin')
-const {
+import {
   textUtilities,
   colorUtilities,
   borderRadiusTokens,
   elevationUtilities,
-} = require('@oxide/design-system/styles/dist/tailwind-tokens')
+} from '@oxide/design-system/styles/dist/tailwind-tokens'
 
-/** @type {import('tailwindcss/tailwind-config').TailwindConfig} */
-module.exports = {
+import { type Config } from 'tailwindcss'
+export default {
   corePlugins: {
     fontFamily: false,
     fontSize: true,
@@ -85,4 +82,4 @@ module.exports = {
       translate: ['group-hover'],
     },
   },
-}
+} satisfies Config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,16 +6,15 @@
  * Copyright Oxide Computer Company
  */
 
+import {
+  borderRadiusTokens,
+  colorUtilities,
+  elevationUtilities,
+  textUtilities,
+} from '@oxide/design-system/styles/dist/tailwind-tokens'
+import { type Config } from 'tailwindcss'
 import plugin from 'tailwindcss/plugin'
 
-import {
-  textUtilities,
-  colorUtilities,
-  borderRadiusTokens,
-  elevationUtilities,
-} from '@oxide/design-system/styles/dist/tailwind-tokens'
-
-import { type Config } from 'tailwindcss'
 export default {
   corePlugins: {
     fontFamily: false,


### PR DESCRIPTION
There is still a type error with the `@oxide/design-system` import. Looking in `node_modules` I don't see an exported type file. Do we need a `design-system` version bump?