### PR TITLE
Fix section toc building

### DIFF
--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -164,7 +164,7 @@ export default function Rfd() {
   useEffect(() => {
     let headings = flattenSections(content.sections)
       .filter((item) => item.level <= 2)
-      .map((item) => bodyRef.current?.querySelector(`#${item.id}`))
+      .map((item) => document.getElementById(item.id))
       .filter(isValue)
 
     setSections(headings)


### PR DESCRIPTION
`item.id` is not guaranteed to be a valid selector, and in the cases that it is it may not actually select the element we want if `item.id` contains a `.` in it's value (causing the selector begin a class match).

Given that we only ever want elements by id, a simple change is to use the `getElementByd` instead. Assuming a well-formed document (without duplicate ids), this will do what we are looking for.

Fixes #98