### PR TITLE
Fix mismatch `@oxide/design-system` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@asciidoctor/core": "^3.0.4",
         "@floating-ui/react": "^0.17.0",
         "@meilisearch/instant-meilisearch": "^0.8.2",
-        "@oxide/design-system": "^3.0.0",
+        "@oxide/design-system": "^2.1.0",
         "@oxide/react-asciidoc": "^1.0.3",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.0.4",
@@ -2307,9 +2307,9 @@
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw=="
     },
     "node_modules/@oxide/design-system": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-3.0.0.tgz",
-      "integrity": "sha512-GB35TIZXD4zEjQjoYKvJqBPuuABD76QJr1pP+huJHKixrQY1UO83DZeqSNBQ6ifdBTTMqLtgHDxcroHLM7BXTQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-2.1.0.tgz",
+      "integrity": "sha512-aQpD+vZQIgkBzi9jcX35m1z1milAf4PzewVH9FlMMGniwUNCXw6G6KT8t3Unnwy3egUQ/qvhdQqm9VSdoDQwsA==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@asciidoctor/core": "^3.0.4",
     "@floating-ui/react": "^0.17.0",
     "@meilisearch/instant-meilisearch": "^0.8.2",
-    "@oxide/design-system": "^3.0.0",
+    "@oxide/design-system": "^2.1.0",
     "@oxide/react-asciidoc": "^1.0.3",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.0.4",


### PR DESCRIPTION
Fixing after some auto version shenanigans. Don't ask!