### PR TITLE
Fix passing search params to prebuilt client

### DIFF
--- a/app/components/Search.tsx
+++ b/app/components/Search.tsx
@@ -79,11 +79,11 @@ const Search = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
         return fetch(
           `/search?q=${
             request.params?.query
-          }&attributes_to_crop=${request.params?.attributesToSnippet?.join(
+          }&attributesToCrop=${request.params?.attributesToSnippet?.join(
             ',',
-          )}&highlight_post_tag=${
+          )}&highlightPostTag=${
             request.params?.highlightPostTag
-          }&highlight_pre_tag=${request.params?.highlightPreTag}`,
+          }&highlightPreTag=${request.params?.highlightPreTag}`,
         ).then(async (resp) => {
           const data = await resp.json()
           return data

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -16,16 +16,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const user = await auth.isAuthenticated(request)
   const url = new URL(request.url)
 
-  const validParams = ['q', 'attributes_to_crop', 'highlight_pre_tag', 'highlight_post_tag']
-  const query = new URLSearchParams()
-
-  for (const [key, value] of url.searchParams.entries()) {
-    if (validParams.includes(key)) {
-      query.set(key, value)
-    }
-  }
-
-  const results = await searchRfds(user, query.toString())
+  const results = await searchRfds(user, url.searchParams.entries())
   return adaptResults(results)
 }
 

--- a/app/services/rfd.remote.server.ts
+++ b/app/services/rfd.remote.server.ts
@@ -116,12 +116,16 @@ export async function searchRfds(
     switch (k) {
       case 'q':
         query.q = v
+        break
       case 'attributesToCrop':
         query.attributesToCrop = v
+        break
       case 'highlightPreTag':
         query.highlightPreTag = v
+        break
       case 'highlightPostTag':
         query.highlightPostTag = v
+        break
     }
   }
 

--- a/app/services/rfd.remote.server.ts
+++ b/app/services/rfd.remote.server.ts
@@ -116,11 +116,11 @@ export async function searchRfds(
     switch (k) {
       case 'q':
         query.q = v
-      case 'attributes_to_crop':
+      case 'attributesToCrop':
         query.attributesToCrop = v
-      case 'highlight_pre_tag':
+      case 'highlightPreTag':
         query.highlightPreTag = v
-      case 'highlight_post_tag':
+      case 'highlightPostTag':
         query.highlightPostTag = v
     }
   }

--- a/app/services/rfd.remote.server.ts
+++ b/app/services/rfd.remote.server.ts
@@ -105,7 +105,10 @@ export async function getRemoteRfds(rfdClient: Api): Promise<RfdWithoutContent[]
   return handleApiResponse(result)
 }
 
-export async function searchRfds(user: User | null, params: IterableIterator<[string, string]>): Promise<SearchResults> {
+export async function searchRfds(
+  user: User | null,
+  params: IterableIterator<[string, string]>,
+): Promise<SearchResults> {
   const rfdClient = client(user?.token || undefined)
   const query: SearchRfdsQueryParams = { q: '' }
 

--- a/app/services/rfd.remote.server.ts
+++ b/app/services/rfd.remote.server.ts
@@ -13,6 +13,7 @@ import type {
   RfdWithoutContent,
   RfdWithRaw,
   SearchResults,
+  SearchRfdsQueryParams,
 } from '@oxide/rfd.ts/client'
 import { ApiWithRetry } from '@oxide/rfd.ts/client-retry'
 
@@ -104,9 +105,24 @@ export async function getRemoteRfds(rfdClient: Api): Promise<RfdWithoutContent[]
   return handleApiResponse(result)
 }
 
-export async function searchRfds(user: User | null, q: string): Promise<SearchResults> {
+export async function searchRfds(user: User | null, params: IterableIterator<[string, string]>): Promise<SearchResults> {
   const rfdClient = client(user?.token || undefined)
-  const result = await rfdClient.methods.searchRfds({ query: { q } })
+  const query: SearchRfdsQueryParams = { q: '' }
+
+  for (let [k, v] of params) {
+    switch (k) {
+      case 'q':
+        query.q = v
+      case 'attributes_to_crop':
+        query.attributesToCrop = v
+      case 'highlight_pre_tag':
+        query.highlightPreTag = v
+      case 'highlight_post_tag':
+        query.highlightPostTag = v
+    }
+  }
+
+  const result = await rfdClient.methods.searchRfds({ query })
   return handleApiResponse(result)
 }
 


### PR DESCRIPTION
Previously we constructed a serialized string and forwarded that to the API. But now that we have an actual client, we should be passing them as a structured object.

This is a fix for https://github.com/oxidecomputer/rfd-api/issues/285