### PR TITLE
Set font in theme and remove letter spacing in mermaid diagrams

### DIFF
--- a/app/components/AsciidocBlocks/Mermaid.tsx
+++ b/app/components/AsciidocBlocks/Mermaid.tsx
@@ -12,6 +12,7 @@ import { memo, useId, useState } from 'react'
 mermaid.initialize({
   startOnLoad: false,
   theme: 'dark',
+  fontFamily: 'SuisseIntl, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif',
 })
 
 const Mermaid = memo(function Mermaid({ content }: { content: string }) {

--- a/app/styles/lib/asciidoc.css
+++ b/app/styles/lib/asciidoc.css
@@ -73,4 +73,10 @@
   .asciidoc-body pre .conum[data-value] {
     @apply text-accent bg-accent-secondary-hover;
   }
+
+  .asciidoc-body svg p {
+    font-size: initial;
+    letter-spacing: initial;
+    font-weight: initial;
+  }
 }


### PR DESCRIPTION
Seems to fix clipping issue on mermaid diagrams