### PR TITLE
Re-enable PDF link and fetch PDF variant on demand

### DIFF
--- a/app/components/rfd/MoreDropdown.tsx
+++ b/app/components/rfd/MoreDropdown.tsx
@@ -38,12 +38,7 @@ const MoreDropdown = () => {
           </DropdownLink>
         )}
 
-        {/* <DropdownLink
-          to={rfd.pdf_link_google_drive || ''}
-          disabled={!rfd.pdf_link_google_drive}
-        >
-          View PDF
-        </DropdownLink> */}
+        <DropdownLink to={`/rfd/${rfd.number}/pdf`}>View PDF</DropdownLink>
       </DropdownMenu>
     </Dropdown.Root>
   )

--- a/app/routes/rfd.$slug.pdf.tsx
+++ b/app/routes/rfd.$slug.pdf.tsx
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { redirect, type LoaderFunction } from '@remix-run/node'
+
+import { isAuthenticated } from '~/services/authn.server'
+import { fetchRfdPdf } from '~/services/rfd.server'
+import { parseRfdNum } from '~/utils/parseRfdNum'
+
+export let loader: LoaderFunction = async ({ request, params: { slug } }) => {
+  const num = parseRfdNum(slug)
+  if (!num) throw new Response('Not Found', { status: 404 })
+
+  const user = await isAuthenticated(request)
+  const rfd = await fetchRfdPdf(num, user)
+
+  if (!rfd || rfd.content.length === 0) throw new Response('Not Found', { status: 404 })
+
+  throw redirect(rfd.content[0].link)
+}

--- a/app/services/rfd.remote.server.ts
+++ b/app/services/rfd.remote.server.ts
@@ -11,6 +11,7 @@ import type {
   Api,
   ApiResult,
   RfdWithoutContent,
+  RfdWithPdf,
   RfdWithRaw,
   SearchResults,
   SearchRfdsQueryParams,
@@ -93,6 +94,26 @@ export async function getRemoteRfd(
   num: number,
 ): Promise<RfdWithRaw | undefined> {
   const result = await rfdClient.methods.viewRfd({ path: { number: num.toString() } })
+
+  if (result.response.status === 404) {
+    return undefined
+  } else {
+    return handleApiResponse(result)
+  }
+}
+
+export async function fetchRemoteRfdPdf(
+  num: number,
+  user: User | null,
+): Promise<RfdWithPdf | undefined> {
+  const rfdClient = client(user?.token || undefined)
+  return await getRemoteRfdPdf(rfdClient, num)
+}
+export async function getRemoteRfdPdf(
+  rfdClient: Api,
+  num: number,
+): Promise<RfdWithPdf | undefined> {
+  const result = await rfdClient.methods.viewRfdPdf({ path: { number: num.toString() } })
 
   if (result.response.status === 404) {
     return undefined

--- a/app/services/rfd.server.ts
+++ b/app/services/rfd.server.ts
@@ -11,6 +11,7 @@ import type { DocumentBlock, DocumentSection } from '@oxide/react-asciidoc'
 import type {
   AccessGroup_for_RfdPermission,
   RfdWithoutContent,
+  RfdWithPdf,
   RfdWithRaw,
 } from '@oxide/rfd.ts/client'
 
@@ -23,7 +24,12 @@ import {
   isLocalMode,
   type LocalRfd,
 } from './rfd.local.server'
-import { fetchRemoteGroups, fetchRemoteRfd, fetchRemoteRfds } from './rfd.remote.server'
+import {
+  fetchRemoteGroups,
+  fetchRemoteRfd,
+  fetchRemoteRfdPdf,
+  fetchRemoteRfds,
+} from './rfd.remote.server'
 
 export type RfdItem = {
   number: number
@@ -80,6 +86,25 @@ export async function fetchRfd(
     } else {
       const rfd = await fetchRemoteRfd(num, user)
       return rfd && apiRfdToItem(rfd)
+    }
+  } catch (err) {
+    console.error('Failed to fetch RFD', err)
+    return undefined
+  }
+}
+
+export async function fetchRfdPdf(
+  num: number,
+  user: User | null,
+): Promise<RfdWithPdf | undefined> {
+  if (num < 1 || num > 9999) return undefined
+
+  try {
+    if (isLocalMode()) {
+      return undefined
+    } else {
+      const rfd = await fetchRemoteRfdPdf(num, user)
+      return rfd
     }
   } catch (err) {
     console.error('Failed to fetch RFD', err)


### PR DESCRIPTION
In the future it would be nice to change this to fetch the PDF from GDrive and stream it bytes directly. This would allow access to PDFs for non-internal users. But for now I think it is fine to rely on GDrive like we did previously.