### PR TITLE
Remove abandoned RFDs from index

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -76,7 +76,7 @@ export default function Index() {
         if (rfd.state === 'abandoned') {
           return false
         }
-        
+
         if (!rfd.authors) {
           return false
         }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -73,6 +73,10 @@ export default function Index() {
 
     if (authorEmailParam || authorNameParam) {
       rfds = rfds.filter((rfd) => {
+        if (rfd.state === 'abandoned') {
+          return false
+        }
+        
         if (!rfd.authors) {
           return false
         }


### PR DESCRIPTION
A recommendation from @bcantrill that we should de-emphasis abandoned RFDs. Effectively we have decided that we are not committing to the contents, and may be misleading.

From RFD 1:
```
Finally, if an idea is found to be non-viable (that is, deliberately never implemented) or if an RFD should be otherwise indicated that it should be ignored, it can be moved into the abandoned state.
```

This change removes them from the index list. We need some backend changes to remove them from search.

This does not delete data, or break direct links. We should also add a warning at the top of abandoned RFDs to re-enforce that they are no longer applicable.