### PR TITLE
Hide create button for anonymous users

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -29,6 +29,10 @@ export type SmallRfdItems = {
 export default function Header({ currentRfd }: { currentRfd?: RfdItem }) {
   const { user, rfds, localMode, inlineComments } = useRootLoaderData()
 
+  // Show create button in local mode or in production only for logged-in internal users
+  const userIsInternal = user?.groups.some((group) => group === 'oxide-employee')
+  const showCreateButton = localMode || userIsInternal
+
   const fetcher = useFetcher()
 
   const toggleTheme = () => {
@@ -80,7 +84,7 @@ export default function Header({ currentRfd }: { currentRfd?: RfdItem }) {
             <Icon name="search" size={16} />
           </button>
           <Search open={open} onClose={() => setOpen(false)} />
-          <NewRfdButton />
+          {showCreateButton && <NewRfdButton />}
 
           {user ? (
             <Dropdown.Root modal={false}>

--- a/app/components/NewRfdButton.tsx
+++ b/app/components/NewRfdButton.tsx
@@ -22,6 +22,7 @@ const NewRfdButton = () => {
       <button
         onClick={dialog.toggle}
         className="text-tertiary bg-secondary border-secondary elevation-1 hover:bg-tertiary flex h-8 w-8 items-center justify-center rounded border"
+        aria-label="Create new RFD"
       >
         <Icon name="add-roundel" size={16} />
       </button>


### PR DESCRIPTION
Here are the the conditions for the showing/hiding the create button:

- Hide create button if user is not logged in
- Hide create button if user is logged in but not an oxide employee
- Always show create button in dev mode (no change)
- Show the the create button if user is logged in and an oxide employee

Added `aria-label="Create new RFD"` for accessibility and for future testing.

I didn't add any tests because it looks like locally the tests only run in dev mode and so the button would be always visible. Looks like we could add some tests to run in CI and they will run in production mode, but we would have to skip them locally. But even if we ran the production tests in CI we don't have any existing logged-in test infrastructure.

Resolves: #64 