### PR TITLE
Add `/rfd/slug/raw` for getting raw asciidoc

### DIFF
--- a/app/routes/rfd.$slug.raw.tsx
+++ b/app/routes/rfd.$slug.raw.tsx
@@ -26,13 +26,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
   // We're replicating some functionality from `fetchRfd` but here we just
   // want the raw content and I don't want to bloat the returned object
   try {
-    if (isLocalMode()) {
-      const localRfd = fetchLocalRfd(num)
-      rfd = localRfd
-    } else {
-      const remoteRfd = await fetchRemoteRfd(num, user)
-      rfd = remoteRfd
-    }
+    rfd = isLocalMode() ? fetchLocalRfd(num) : await fetchRemoteRfd(num, user)
   } catch (err) {
     console.error('Failed to fetch RFD', err)
     throw resp404()


### PR DESCRIPTION
Doesn't quite fix #181, since it's the processed and combined document, but that seems perhaps like a niche use case and we can't get that from the API.

@sunshowers is this useful? Not sure how you'd auth for non-public RFDs from an agent or CLI.