### PR TITLE
Updates RFD selection phrasing

### DIFF
--- a/app/components/SelectRfdCombobox.tsx
+++ b/app/components/SelectRfdCombobox.tsx
@@ -49,13 +49,13 @@ const SelectRfdCombobox = ({
             isLoggedIn ? 'max-w-[160px]' : 'max-w-[100px]',
           )}
         >
-          {currentRfd ? currentRfd.title : 'Select a RFD'}
+          {currentRfd ? currentRfd.title : 'Select an RFD'}
         </div>
       </div>
       <button
         onClick={toggleCombobox}
         className="text-tertiary border-secondary hover:bg-hover 600:ml-6 ml-2 flex h-[32px] w-[18px] items-center justify-center rounded border"
-        aria-label="Select a RFD"
+        aria-label="Select an RFD"
       >
         <Icon name="select-arrows" size={6} className="shrink-0" height={14} />
       </button>

--- a/test/e2e/everything.spec.ts
+++ b/test/e2e/everything.spec.ts
@@ -68,7 +68,7 @@ test.describe('Navigation and Basic Functionality', () => {
 
     await expect(page.getByRole('banner').getByPlaceholder('Search')).toBeHidden()
 
-    await page.getByRole('button', { name: 'Select a RFD' }).click()
+    await page.getByRole('button', { name: 'Select an RFD' }).click()
     await page.getByRole('banner').getByPlaceholder('Search').fill('Mission')
     await page.getByRole('banner').getByPlaceholder('Search').press('Enter')
 


### PR DESCRIPTION
Changes the phrasing in the RFD selection component and associated tests from "Select a RFD" to "Select an RFD" for improved grammatical correctness and 'clout'.