### PR TITLE
Fix max width

### DIFF
--- a/app/components/AsciidocBlocks/Footnotes.tsx
+++ b/app/components/AsciidocBlocks/Footnotes.tsx
@@ -35,7 +35,7 @@ const Footnotes = ({ doc }: { doc: DocumentBlock }) => {
                 <div className="text-mono-xs text-default bg-tertiary absolute -top-[2px] -left-12 flex shrink-0 items-center justify-center rounded-full px-[4px] py-[2px] tracking-normal!">
                   {footnote.index}
                 </div>
-                <div className="text-sans-md text-default max-w-800">
+                <div className="text-sans-md text-default max-w-200">
                   <p
                     dangerouslySetInnerHTML={{ __html: footnote.text || '' }}
                     className="inline"

--- a/app/components/Container.tsx
+++ b/app/components/Container.tsx
@@ -22,7 +22,7 @@ const Container = ({
   <div className={cn('600:px-10 w-full px-5', wrapperClassName)}>
     <div
       className={cn(
-        'm-auto max-w-1200',
+        'm-auto max-w-300',
         className,
         isGrid ? '600:gap-6 grid grid-cols-12 gap-4' : '',
       )}

--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -257,7 +257,7 @@ export default function Rfd() {
             <AccessWarning groups={groups} />
           </div>
         </Container>
-        <div className="border-secondary border-b print:m-auto print:max-w-1200 print:rounded-lg print:border">
+        <div className="border-secondary border-b print:m-auto print:max-w-300 print:rounded-lg print:border">
           {state && (
             <PropertyRow
               label="State"


### PR DESCRIPTION
`800` !== `800px`. It's actually 800 x 4px.

Slight quirk of the way containers were defined before and updated in the latest version.

Effectively this meant there was no more max width.