### PR TITLE
Extract text diff

### DIFF
--- a/app/components/rfd/RfdInlineComments.tsx
+++ b/app/components/rfd/RfdInlineComments.tsx
@@ -25,7 +25,6 @@ import uniqBy from 'lodash/uniqBy'
 import { marked } from 'marked'
 import { useEffect, useMemo, useState } from 'react'
 import { renderToString } from 'react-dom/server'
-import diff from 'simple-text-diff'
 
 import Container from '~/components/Container'
 import Icon from '~/components/Icon'
@@ -35,6 +34,7 @@ import type {
   ListReviewsCommentsType,
   ReviewCommentsType,
 } from '~/services/github-discussion.server'
+import { diffPatchBySeparator } from '~/utils/textDiff'
 
 import { calcOffset } from './RfdPreview'
 
@@ -301,7 +301,7 @@ const CodeSuggestion = ({
   suggestion: string
   isOverlay: boolean
 }) => {
-  const textDiff = diff.diffPatchBySeparator(original, suggestion, ' ')
+  const textDiff = diffPatchBySeparator(original, suggestion, ' ')
   return (
     <div
       className={cn(

--- a/app/utils/textDiff.test.ts
+++ b/app/utils/textDiff.test.ts
@@ -1,0 +1,99 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { diffPatch, diffPatchBySeparator } from './textDiff'
+
+describe('diffPatch', () => {
+  test('identical strings produce no markup', () => {
+    expect(diffPatch('hello', 'hello')).toEqual({ before: 'hello', after: 'hello' })
+  })
+
+  test('pure insertion only marks the after', () => {
+    expect(diffPatch('', 'abc')).toEqual({ before: '', after: '<ins>abc</ins>' })
+  })
+
+  test('pure deletion only marks the before', () => {
+    expect(diffPatch('abc', '')).toEqual({ before: '<del>abc</del>', after: '' })
+  })
+
+  test('mixed edit marks the differing runs on each side', () => {
+    expect(diffPatch('cat', 'car')).toEqual({
+      before: 'ca<del>t</del>',
+      after: 'ca<ins>r</ins>',
+    })
+  })
+
+  test('empty inputs return empty strings', () => {
+    expect(diffPatch('', '')).toEqual({ before: '', after: '' })
+    expect(diffPatch()).toEqual({ before: '', after: '' })
+  })
+
+  test('equal runs are shared between before and after', () => {
+    const { before, after } = diffPatch('the quick fox', 'the slow fox')
+    expect(before).toBe('the <del>quick</del> fox')
+    expect(after).toBe('the <ins>slow</ins> fox')
+  })
+})
+
+describe('diffPatchBySeparator', () => {
+  test('identical inputs round-trip unchanged', () => {
+    expect(diffPatchBySeparator('a,b,c', 'a,b,c')).toEqual({
+      before: 'a,b,c',
+      after: 'a,b,c',
+    })
+  })
+
+  test('word-level diff with space separator', () => {
+    expect(diffPatchBySeparator('the quick brown fox', 'the slow brown fox', ' ')).toEqual(
+      {
+        before: 'the <del>quick</del> brown fox',
+        after: 'the <ins>slow</ins> brown fox',
+      },
+    )
+  })
+
+  test('defaults to comma separator', () => {
+    expect(diffPatchBySeparator('a,b,c', 'a,x,c')).toEqual({
+      before: 'a,<del>b</del>,c',
+      after: 'a,<ins>x</ins>,c',
+    })
+  })
+
+  test('pure insertion of a segment', () => {
+    expect(diffPatchBySeparator('a b', 'a b c', ' ')).toEqual({
+      before: 'a b',
+      after: 'a b <ins>c</ins>',
+    })
+  })
+
+  test('pure deletion of a segment', () => {
+    expect(diffPatchBySeparator('a b c', 'a b', ' ')).toEqual({
+      before: 'a b <del>c</del>',
+      after: 'a b',
+    })
+  })
+
+  test('empty inputs return empty strings', () => {
+    expect(diffPatchBySeparator('', '', ' ')).toEqual({ before: '', after: '' })
+  })
+
+  test('segments missing from the other side are marked on their own side only', () => {
+    const { before, after } = diffPatchBySeparator('a b c d', 'a x c y', ' ')
+    expect(before).toBe('a <del>b</del> c <del>d</del>')
+    expect(after).toBe('a <ins>x</ins> c <ins>y</ins>')
+  })
+
+  test('empty segments from repeated separators are preserved without markup', () => {
+    expect(diffPatchBySeparator('a  b', 'a  b', ' ')).toEqual({
+      before: 'a  b',
+      after: 'a  b',
+    })
+  })
+})

--- a/app/utils/textDiff.test.ts
+++ b/app/utils/textDiff.test.ts
@@ -51,12 +51,10 @@ describe('diffPatchBySeparator', () => {
   })
 
   test('word-level diff with space separator', () => {
-    expect(diffPatchBySeparator('the quick brown fox', 'the slow brown fox', ' ')).toEqual(
-      {
-        before: 'the <del>quick</del> brown fox',
-        after: 'the <ins>slow</ins> brown fox',
-      },
-    )
+    expect(diffPatchBySeparator('the quick brown fox', 'the slow brown fox', ' ')).toEqual({
+      before: 'the <del>quick</del> brown fox',
+      after: 'the <ins>slow</ins> brown fox',
+    })
   })
 
   test('defaults to comma separator', () => {

--- a/app/utils/textDiff.ts
+++ b/app/utils/textDiff.ts
@@ -1,0 +1,62 @@
+// Based on https://github.com/zhenghuahou/text-diff
+import Diff from 'fast-diff'
+
+type Operation = -1 | 0 | 1
+
+interface DiffPatchResult {
+  before: string
+  after: string
+}
+
+function format(operation: Operation, txt: string): string {
+  if (!txt) return txt
+  if (operation === Diff.DELETE) return `<del>${txt}</del>`
+  if (operation === Diff.INSERT) return `<ins>${txt}</ins>`
+  return txt
+}
+
+/** Character-level diff of two strings with <del>/<ins> markup on the changed runs. */
+export function diffPatch(oldText = '', newText = ''): DiffPatchResult {
+  let before = ''
+  let after = ''
+  for (const [operation, str] of Diff(oldText, newText)) {
+    if (operation !== Diff.INSERT) before += format(operation, str)
+    if (operation !== Diff.DELETE) after += format(operation, str)
+  }
+  return { before, after }
+}
+
+function getPatchText(
+  revisionArr: string[],
+  intersectSet: Set<string>,
+  separator: string,
+  isBefore: boolean,
+): string {
+  return revisionArr
+    .map((segment) => {
+      const operation = intersectSet.has(segment)
+        ? Diff.EQUAL
+        : isBefore
+          ? Diff.DELETE
+          : Diff.INSERT
+      return format(operation, segment)
+    })
+    .join(separator)
+}
+
+/** Split both inputs by `separator`, then mark segments that differ with <del>/<ins>. */
+export function diffPatchBySeparator(
+  oldText = '',
+  newText = '',
+  separator = ',',
+): DiffPatchResult {
+  const originalArr = oldText.split(separator)
+  const compareArr = newText.split(separator)
+  const originalSet = new Set(originalArr)
+  const intersectSet = new Set(compareArr.filter((x) => originalSet.has(x)))
+
+  return {
+    before: getPatchText(originalArr, intersectSet, separator, true),
+    after: getPatchText(compareArr, intersectSet, separator, false),
+  }
+}

--- a/app/utils/textDiff.ts
+++ b/app/utils/textDiff.ts
@@ -1,3 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
 // Based on https://github.com/zhenghuahou/text-diff
 import Diff from 'fast-diff'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vercel/react-router": "^1.2.6",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.18",
+        "fast-diff": "^1.3.0",
         "highlight.js": "^11.11.1",
         "html-entities": "^2.6.0",
         "isbot": "^5",
@@ -43,7 +44,6 @@
         "remix-auth": "^4.2.0",
         "remix-auth-oauth2": "^3.4.1",
         "shiki": "^3.13.0",
-        "simple-text-diff": "^1.7.0",
         "zod": "^3.23.8",
         "zustand": "^5.0.11"
       },
@@ -12192,15 +12192,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-text-diff": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/simple-text-diff/-/simple-text-diff-1.7.0.tgz",
-      "integrity": "sha512-IQzeFnG66XPGWS2UjeVFGDAcUk2LFJEbTv52Vb4/YzNzWrBVwzHcNUdNxF0y7QK8NkdW43LX6mljroDyBfPK2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.2.0"
-      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "isbot": "^5",
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
-        "marked": "16.3.0",
+        "marked": "^18.0.2",
         "mermaid": "^11.12.0",
         "mime-types": "^3.0.1",
         "mousetrap": "^1.6.5",
@@ -9723,9 +9723,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
-      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -9831,6 +9831,18 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/methods": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@floating-ui/react": "^0.17.0",
         "@leeoniya/ufuzzy": "^1.0.19",
         "@meilisearch/instant-meilisearch": "^0.28.0",
-        "@oxide/design-system": "^6.2.0",
+        "@oxide/design-system": "^6.2.1",
         "@oxide/react-asciidoc": "^1.3.0",
         "@oxide/remix-auth-rfd": "^0.1.3",
         "@oxide/rfd.ts": "^0.14.1",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@oxide/design-system": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.2.0.tgz",
-      "integrity": "sha512-KtbIj01OJhT8fu/GaaI4E8Ab670JsMWIc4DUNM0K7H2jv5dFwH4l/Q51Zy0Jp4ZfzRD6FjfV/eu8kgGoJZdrxg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.2.1.tgz",
+      "integrity": "sha512-1QBu1CVLx20AI9QHOo/m7yFslghpYfHhHxa7r/74NV6Ff/RawkUQjl7X+NgFxLyf3jJehWgWBhcycxM+Bw1q3A==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "isbot": "^5",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "marked": "16.3.0",
+    "marked": "^18.0.2",
     "mermaid": "^11.12.0",
     "mime-types": "^3.0.1",
     "mousetrap": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@floating-ui/react": "^0.17.0",
     "@leeoniya/ufuzzy": "^1.0.19",
     "@meilisearch/instant-meilisearch": "^0.28.0",
-    "@oxide/design-system": "^6.2.0",
+    "@oxide/design-system": "^6.2.1",
     "@oxide/react-asciidoc": "^1.3.0",
     "@oxide/remix-auth-rfd": "^0.1.3",
     "@oxide/rfd.ts": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@vercel/react-router": "^1.2.6",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.18",
+    "fast-diff": "^1.3.0",
     "highlight.js": "^11.11.1",
     "html-entities": "^2.6.0",
     "isbot": "^5",
@@ -54,7 +55,6 @@
     "remix-auth": "^4.2.0",
     "remix-auth-oauth2": "^3.4.1",
     "shiki": "^3.13.0",
-    "simple-text-diff": "^1.7.0",
     "zod": "^3.23.8",
     "zustand": "^5.0.11"
   },


### PR DESCRIPTION
Follow up to #206 

The `marked` error was a red herring, though a good opportunity to make that more robust.

If I had to guess I think one of the dep upgrades, likely Vite, meant the site stopped handling the `require` import in the `simple-text-diff` library. I suspect this would be solvable through some vite config voodoo but the simplest thing here is just to inline the library since it's so small.