### PR TITLE
Disable React Router's lazy route discovery

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -12,4 +12,7 @@ import { vercelPreset } from '@vercel/react-router/vite'
 export default {
   presets: [vercelPreset()],
   ssr: true,
+  // we have few routes, so skip lazy route discovery (and its /__manifest
+  // endpoint) and ship the full route manifest in the initial document
+  routeDiscovery: { mode: 'initial' },
 } satisfies Config


### PR DESCRIPTION
We found in the docs site that this improves performance of navs a decent amount right after a deploy. On the RFD site we don't really have a problem with this (still not entirely sure why it happens on the docs site) but lazy-loading the route manifest is unnecessary on a site with only 20 routes. The manifest is one 9kb (2kb gzipped) response and it's cached client-side once and you're done. 

<img width="1111" height="154" alt="image" src="https://github.com/user-attachments/assets/790753a4-de85-4d35-867b-b5d152928c30" />
