### PR TITLE
ci: Bump and pin GitHub Actions layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/licence-check.yml
+++ b/.github/workflows/licence-check.yml
@@ -13,6 +13,6 @@ jobs:
   license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check License Header
-        uses: apache/skywalking-eyes/header@5dfa68f93380a5e57259faaf95088b7f133b5778
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,3 +1,4 @@
+# schema: https://json.schemastore.org/github-workflow.json
 name: Playwright Tests
 
 # This is an unusual job because it's triggered by deploy events rather than
@@ -7,7 +8,6 @@ name: Playwright Tests
 on:
   deployment_status:
 
-# schema: https://json.schemastore.org/github-workflow.json
 jobs:
   playwright:
     if:
@@ -31,7 +31,7 @@ jobs:
         run: npx playwright test
         env:
           BASE_URL: ${{ github.event.deployment_status.target_url }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,7 @@ name: Playwright Tests
 on:
   deployment_status:
 
+# schema: https://json.schemastore.org/github-workflow.json
 jobs:
   playwright:
     if:
@@ -15,10 +16,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -30,7 +31,7 @@ jobs:
         run: npx playwright test
         env:
           BASE_URL: ${{ github.event.deployment_status.target_url }}
-      - uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
Pin GitHub actions to full sha1 hashes rather than refs (`v3`, etc) because the latter are unstable and can change.

For example, these three all currently point to https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
- [actions/checkout@v7](https://github.com/actions/checkout/releases/tag/v7)
- [actions/checkout@v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0)
- [actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0](https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)

The first one **will** change (updated tag forced pushed to replace old tag)
The second one **could** change
The third one **will never** change

For any 3rd party action we should absolutely pin because one tag force push with compromised credentials and we'd be running arbitrary code.

If an actions repos adopted [Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) we could safely use the `@v7.0.0` style pin, but none of the first party `actions/*` repos have done so as it would mean that they could no longer publish tags like `v7`. See:
- https://github.com/actions/checkout/issues/2316

The format of putting the tag in a trailing comment matches that of renovate. This repo is not currently configured for renovate, although I think that would be reasonable to do in the future.