### PR TITLE
Hide 'viewing public RFDs' banner in local mode

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -67,7 +67,7 @@ export default function Header({ currentRfd }: { currentRfd?: RfdItem }) {
 
   return (
     <div className="sticky top-0 z-60">
-      {!user && <PublicBanner />}
+      {!user && !localMode && <PublicBanner />}
       <header className="bg-default border-secondary flex h-14 items-center justify-between border-b px-3 print:hidden">
         <div className="flex space-x-3">
           <Link


### PR DESCRIPTION
The banner makes no sense in local mode.

<img width="944" height="388" alt="image" src="https://github.com/user-attachments/assets/4bb5180a-9058-4431-944a-71c7d1066e1b" />
