### PR TITLE
Fix for stale jwt cookie

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,7 @@ import {
 import styles from '~/styles/index.css?url'
 
 import LoadingBar from './components/LoadingBar'
-import { authenticate, logout } from './services/auth.server'
+import { authenticate, logoutOnAuthError } from './services/auth.server'
 import { inlineCommentsCookie } from './services/cookies.server'
 import { isLocalMode } from './services/rfd.local.server'
 import {
@@ -53,36 +53,21 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     (await inlineCommentsCookie.parse(request.headers.get('Cookie'))) ?? true
 
   const user = await authenticate(request)
-  try {
-    const rfds = (await fetchRfds(user)) || []
 
-    const authors = rfds ? getAuthors(rfds) : []
-    const labels = rfds ? getLabels(rfds) : []
+  // If the API rejects the session's token (e.g. it predates an API upgrade),
+  // clear the session and reload this URL logged out. Without this, a user
+  // with a dead token sees 404s everywhere — including on public RFDs — and
+  // /login bounces them away because a session cookie still exists.
+  const rfds = (await logoutOnAuthError(request, () => fetchRfds(user))) || []
 
-    return {
-      inlineComments,
-      user,
-      rfds,
-      authors,
-      labels,
-      localMode: isLocalMode(),
-      newRfdNumber: provideNewRfdNumber([...rfds]),
-    }
-  } catch {
-    // The only error that should be caught here is the unauthenticated error.
-    // And if that occurs we need to log the user out
-    await logout(request, '/')
-  }
-
-  // Convince remix that a return type will always be provided
   return {
     inlineComments,
     user,
-    rfds: [],
-    authors: [],
-    labels: [],
+    rfds,
+    authors: getAuthors(rfds),
+    labels: getLabels(rfds),
     localMode: isLocalMode(),
-    newRfdNumber: undefined,
+    newRfdNumber: provideNewRfdNumber([...rfds]),
   }
 }
 

--- a/app/routes/api.rfd.$slug.discussion.tsx
+++ b/app/routes/api.rfd.$slug.discussion.tsx
@@ -8,8 +8,9 @@
 
 import { data, type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutStaleSession } from '~/services/auth.server'
 import { fetchDiscussion } from '~/services/github-discussion.server'
+import { AuthenticationError } from '~/services/rfd.remote.server'
 import { parseRfdNum } from '~/utils/parseRfdNum'
 
 export async function loader({ request, params: { slug } }: LoaderFunctionArgs) {
@@ -29,6 +30,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
 
     return discussion
   } catch (error) {
+    if (error instanceof AuthenticationError) await logoutStaleSession(request)
     console.error('Error fetching discussion:', error)
     return data({ error: 'Failed to fetch discussion' }, { status: 500 })
   }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -19,8 +19,14 @@ import {
   type MetaFunction,
 } from 'react-router'
 
-import { auth, getUserFromSession, sanitizeRedirect } from '~/services/auth.server'
+import {
+  auth,
+  getUserFromSession,
+  isSessionValid,
+  sanitizeRedirect,
+} from '~/services/auth.server'
 import { returnToCookie } from '~/services/cookies.server'
+import { sessionStorage } from '~/services/session.server'
 import { buildMeta } from '~/utils/meta'
 
 export const meta: MetaFunction = () =>
@@ -35,15 +41,24 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const returnTo = url.searchParams.get('returnTo')
   const emailResponse = url.searchParams.get('email')
 
+  const headers = new Headers()
+  headers.append('Cache-Control', 'no-cache')
+
   // If we're already logged in, honor returnTo if present (e.g. an auth-gated
   // RFD redirected here), otherwise go home. This may also occur while
   // navigating back/forward or from history.
-  if (await getUserFromSession(request)) {
-    throw redirect(returnTo ? sanitizeRedirect(returnTo) : '/')
+  const user = await getUserFromSession(request)
+  if (user) {
+    if (await isSessionValid(user)) {
+      throw redirect(returnTo ? sanitizeRedirect(returnTo) : '/')
+    }
+    // The cookie exists but the API rejects its token (e.g. it predates an
+    // API upgrade). Clear it and show the login page — bouncing away here
+    // would leave the user with no way to re-authenticate.
+    const session = await sessionStorage.getSession(request.headers.get('Cookie'))
+    session.unset('user')
+    headers.append('Set-Cookie', await sessionStorage.commitSession(session))
   }
-
-  const headers = new Headers()
-  headers.append('Cache-Control', 'no-cache')
 
   if (returnTo) {
     headers.append('Set-Cookie', await returnToCookie.serialize(returnTo))

--- a/app/routes/rfd.$slug.discussion.tsx
+++ b/app/routes/rfd.$slug.discussion.tsx
@@ -8,7 +8,7 @@
 
 import { redirect, type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchRfd } from '~/services/rfd.server'
 import { formatRfdNum } from '~/utils/canonicalUrl'
 import { parseRfdNum } from '~/utils/parseRfdNum'
@@ -20,7 +20,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
   if (!num) throw resp404()
 
   const user = await authenticate(request)
-  const rfd = await fetchRfd(num, user)
+  const rfd = await logoutOnAuthError(request, () => fetchRfd(num, user))
 
   // !rfd covers both non-existent and private RFDs for the logged-out user. In
   // both cases, once they log in, if they have permission to read it, they'll

--- a/app/routes/rfd.$slug.fetch.tsx
+++ b/app/routes/rfd.$slug.fetch.tsx
@@ -8,7 +8,7 @@
 
 import type { LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchRfd } from '~/services/rfd.server'
 import { parseRfdNum } from '~/utils/parseRfdNum'
 
@@ -17,7 +17,7 @@ export const loader = async ({ request, params: { slug } }: LoaderFunctionArgs) 
   if (!num) throw new Response('Not Found', { status: 404 })
 
   const user = await authenticate(request)
-  const rfd = await fetchRfd(num, user)
+  const rfd = await logoutOnAuthError(request, () => fetchRfd(num, user))
 
   if (!rfd) throw new Response('Not Found', { status: 404 })
 

--- a/app/routes/rfd.$slug.jobs.tsx
+++ b/app/routes/rfd.$slug.jobs.tsx
@@ -7,7 +7,7 @@
  */
 import { data, type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchRfdJobs } from '~/services/rfd.server'
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -18,7 +18,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 
   const user = await authenticate(request)
-  const jobs = await fetchRfdJobs(rfdNumber, user)
+  const jobs = await logoutOnAuthError(request, () => fetchRfdJobs(rfdNumber, user))
 
   return data(jobs)
 }

--- a/app/routes/rfd.$slug.pdf.download.tsx
+++ b/app/routes/rfd.$slug.pdf.download.tsx
@@ -8,7 +8,7 @@
 
 import { redirect, type LoaderFunction } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchRfdPdf } from '~/services/rfd.server'
 import { parseRfdNum } from '~/utils/parseRfdNum'
 
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async ({ request, params: { slug } }) => {
   if (!num) throw new Response('Not Found', { status: 404 })
 
   const user = await authenticate(request)
-  const rfd = await fetchRfdPdf(num, user)
+  const rfd = await logoutOnAuthError(request, () => fetchRfdPdf(num, user))
 
   if (!rfd || rfd.content.length === 0) throw new Response('Not Found', { status: 404 })
 

--- a/app/routes/rfd.$slug.pdf.tsx
+++ b/app/routes/rfd.$slug.pdf.tsx
@@ -8,7 +8,7 @@
 
 import { redirect, type LoaderFunction } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchRfdPdf } from '~/services/rfd.server'
 import { formatRfdNum } from '~/utils/canonicalUrl'
 import { parseRfdNum } from '~/utils/parseRfdNum'
@@ -18,7 +18,7 @@ export const loader: LoaderFunction = async ({ request, params: { slug } }) => {
   if (!num) throw new Response('Not Found', { status: 404 })
 
   const user = await authenticate(request)
-  const rfd = await fetchRfdPdf(num, user)
+  const rfd = await logoutOnAuthError(request, () => fetchRfdPdf(num, user))
 
   // If someone goes to a private RFD's PDF but they're not logged in, they will
   // want to log in and see it. Send them back to the PDF they asked for.

--- a/app/routes/rfd.$slug.raw.tsx
+++ b/app/routes/rfd.$slug.raw.tsx
@@ -9,9 +9,9 @@
 import { RfdWithRaw } from '@oxide/rfd.ts/client'
 import { redirect, type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutStaleSession } from '~/services/auth.server'
 import { fetchLocalRfd, isLocalMode, LocalRfd } from '~/services/rfd.local.server'
-import { fetchRemoteRfd } from '~/services/rfd.remote.server'
+import { AuthenticationError, fetchRemoteRfd } from '~/services/rfd.remote.server'
 import { formatRfdNum } from '~/utils/canonicalUrl'
 import { parseRfdNum } from '~/utils/parseRfdNum'
 
@@ -29,6 +29,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
   try {
     rfd = isLocalMode() ? fetchLocalRfd(num) : await fetchRemoteRfd(num, user)
   } catch (err) {
+    if (err instanceof AuthenticationError) await logoutStaleSession(request)
     console.error('Failed to fetch RFD', err)
     throw resp404()
   }

--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -44,7 +44,7 @@ import RfdInlineComments from '~/components/rfd/RfdInlineComments'
 import RfdPreview from '~/components/rfd/RfdPreview'
 import StatusBadge from '~/components/StatusBadge'
 import { useRootLoaderData } from '~/root'
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchGroups, fetchRfd } from '~/services/rfd.server'
 import { formatRfdNum } from '~/utils/canonicalUrl'
 import { buildMeta } from '~/utils/meta'
@@ -85,7 +85,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
 
   const user = await authenticate(request)
 
-  const rfd = await fetchRfd(num, user)
+  const rfd = await logoutOnAuthError(request, () => fetchRfd(num, user))
 
   // If someone goes to a private RFD but they're not logged in, they will
   // want to log in and see it.
@@ -100,7 +100,7 @@ export async function loader({ request, params: { slug } }: LoaderFunctionArgs) 
   // necessarily exhaustive. The permissions assigned to this user will determine
   // which groups they are allowed to list. The list returned from the API is
   // then filtered down to include only the groups that provide access to this RFD.
-  const groups = (await fetchGroups(user))
+  const groups = (await logoutOnAuthError(request, () => fetchGroups(user)))
     .filter((group) => can(group.permissions, { GetRfd: num }))
     .map((g) => g.name)
 

--- a/app/routes/rfd.image.$rfd.$.tsx
+++ b/app/routes/rfd.image.$rfd.$.tsx
@@ -8,7 +8,7 @@
 
 import { redirect, type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { fetchLocalImage, isLocalMode } from '~/services/rfd.local.server'
 import { fetchRfd } from '~/services/rfd.server'
 import { getExpiringUrl } from '~/services/storage.server'
@@ -41,7 +41,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     })
   } else {
     const user = await authenticate(request)
-    const remoteRfd = await fetchRfd(rfdNumber, user)
+    const remoteRfd = await logoutOnAuthError(request, () => fetchRfd(rfdNumber, user))
 
     // If the user can read the RFD than they can access the images in the RFD
     if (remoteRfd) {

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -9,14 +9,16 @@
 import type { SearchResults } from '@oxide/rfd.ts/client'
 import { type LoaderFunctionArgs } from 'react-router'
 
-import { authenticate } from '~/services/auth.server'
+import { authenticate, logoutOnAuthError } from '~/services/auth.server'
 import { searchRfds } from '~/services/rfd.remote.server'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await authenticate(request)
   const url = new URL(request.url)
 
-  const results = await searchRfds(user, url.searchParams.entries())
+  const results = await logoutOnAuthError(request, () =>
+    searchRfds(user, url.searchParams.entries()),
+  )
   return adaptResults(results)
 }
 

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -20,7 +20,12 @@ import { Authenticator } from 'remix-auth'
 import { isTruthy } from '~/utils/isTruthy'
 
 import { returnToCookie } from './cookies.server'
-import { client, fetchRemoteGroups, handleApiResponse } from './rfd.remote.server'
+import {
+  AuthenticationError,
+  client,
+  fetchRemoteGroups,
+  handleApiResponse,
+} from './rfd.remote.server'
 import { sessionStorage } from './session.server'
 
 export type User = {
@@ -145,6 +150,52 @@ export async function logout(request: Request, redirectTo: string) {
   throw redirect(redirectTo, {
     headers: { 'Set-Cookie': await sessionStorage.commitSession(session) },
   })
+}
+
+/**
+ * Clear the session and reload the same URL logged out. For recovering from a
+ * session whose access token the API no longer accepts (e.g. tokens issued
+ * before an rfd-api upgrade): being "logged in" with a dead token renders
+ * every RFD as a 404, while logged out the public ones are visible and the
+ * login page is reachable. Always throws (a redirect).
+ */
+export async function logoutStaleSession(request: Request): Promise<never> {
+  const { pathname, search } = new URL(request.url)
+  await logout(request, pathname + search)
+  throw new Error('unreachable: logout always throws a redirect')
+}
+
+/**
+ * Run an API-fetching function, and if it fails because the API rejected the
+ * session's access token, self-heal via logoutStaleSession. Other errors
+ * (including thrown Responses) propagate unchanged.
+ */
+export async function logoutOnAuthError<T>(
+  request: Request,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    if (err instanceof AuthenticationError) {
+      await logoutStaleSession(request)
+    }
+    throw err
+  }
+}
+
+/**
+ * Whether the API still accepts the session's access token. Only a definitive
+ * 401 counts as invalid; other failures (network, 5xx) say nothing about the
+ * session and shouldn't log anyone out.
+ */
+export async function isSessionValid(user: User): Promise<boolean> {
+  try {
+    handleApiResponse(await client(user.token).methods.getSelf({}))
+    return true
+  } catch (err) {
+    return !(err instanceof AuthenticationError)
+  }
 }
 
 async function handleAuthenticationCallback(provider: string, request: Request) {

--- a/app/services/rfd.server.ts
+++ b/app/services/rfd.server.ts
@@ -26,6 +26,7 @@ import {
   type LocalRfd,
 } from './rfd.local.server'
 import {
+  AuthenticationError,
   fetchRemoteGroups,
   fetchRemoteRfd,
   fetchRemoteRfdJobs,
@@ -92,6 +93,9 @@ export async function fetchRfd(
       return rfd && apiRfdToItem(rfd)
     }
   } catch (err) {
+    // A 401 means the session's token is dead, not that the RFD is missing.
+    // Let callers distinguish that from a 404 so they can clear the session.
+    if (err instanceof AuthenticationError) throw err
     console.error('Failed to fetch RFD', err)
     return undefined
   }
@@ -107,6 +111,7 @@ export async function fetchRfdJobs(num: number, user: User | null): Promise<Job[
       return await fetchRemoteRfdJobs(num, user)
     }
   } catch (err) {
+    if (err instanceof AuthenticationError) throw err
     console.error('Failed to fetch RFD jobs', err)
     return []
   }
@@ -126,6 +131,7 @@ export async function fetchRfdPdf(
       return rfd
     }
   } catch (err) {
+    if (err instanceof AuthenticationError) throw err
     console.error('Failed to fetch RFD', err)
     return undefined
   }
@@ -138,6 +144,7 @@ export async function fetchRfds(user: User | null): Promise<RfdListItem[] | unde
       : (await fetchRemoteRfds(user)).map(apiRfdMetaToListItem)
     return mergeAuthorVariants(rfds)
   } catch (err) {
+    if (err instanceof AuthenticationError) throw err
     console.error('Failed to fetch RFD', err)
     return undefined
   }


### PR DESCRIPTION
- Closes: https://github.com/oxidecomputer/rfd-api/issues/492

Since the [rfd-api v0.15.0](https://github.com/oxidecomputer/rfd-api/releases/tag/v0.15.0) release on Monday 2026-07-20 access tokens issued before the upgrade fail JWT claims parsing. The scp claim changed from a JSON array to a space-delimited string. Every API call made with an old one returns 401.

## Issue

- `fetchRfd/fetchRfds` swallowed the 401 and returned "not found" -- Users with a stale cookie saw 404s on every RFD (even public RFDs)
- `/login` redirected if a session cookie existed, without validating the token worked -- Affected users couldn't re-authenticate.
- `/logout` is POST-only, leaving no self-service escape hatch.

## Solution

- Fetch helpers rethrow `AuthenticationError` rather than 404.
- New `logoutOnAuthError` / `logoutStaleSession` clear session on a real 401 and reload the same URL logged out
- `/login` now validates the session token via getSelf before bouncing; a dead session is cleared and the login form renders. Only a 401 counts as invalid — network errors an
5xxs never log anyone out.

## User Action

After deploy, anyone with old cookies will have them automatically deleted on next page view. Login should then succeed.