### PR TITLE
Bump node, typescript, eslint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm install
       - name: Check format

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm install

--- a/app/components/AsciidocBlocks/Image.tsx
+++ b/app/components/AsciidocBlocks/Image.tsx
@@ -18,17 +18,12 @@ function nodeIsInline(node: Block | Inline): node is Inline {
 const InlineImage = ({ node }: { node: Block | Inline }) => {
   const documentAttrs = node.getDocument().getAttributes()
 
-  let target = ''
-  if (nodeIsInline(node)) {
-    target = node.getTarget() || '' // Getting target on inline nodes
-  } else {
-    target = node.getAttribute('target') // Getting target on block nodes
-  }
+  const target = nodeIsInline(node)
+    ? node.getTarget() || '' // Getting target on inline nodes
+    : node.getAttribute('target') // Getting target on block nodes
 
   const uri = node.getImageUri(target)
-  let url = ''
-
-  url = `/rfd/image/${documentAttrs.rfdnumber}/${uri}`
+  const url = `/rfd/image/${documentAttrs.rfdnumber}/${uri}`
 
   let img = (
     <img
@@ -64,11 +59,9 @@ const Image = ({ node }: { node: ImageBlock }) => {
   const { document } = useConverterContext()
   const docAttrs = document.attributes || {}
 
-  let url = ''
-
   const [lightboxOpen, setLightboxOpen] = useState(false)
 
-  url = `/rfd/image/${docAttrs.rfdnumber}/${node.imageUri}`
+  const url = `/rfd/image/${docAttrs.rfdnumber}/${node.imageUri}`
 
   let img = (
     <img

--- a/app/components/LoadingBar.tsx
+++ b/app/components/LoadingBar.tsx
@@ -40,10 +40,10 @@ function LoadingBar() {
 
   // only used for checking the loading state from inside the timeout callback
   const loadingRef = useRef(false)
-  loadingRef.current = navigation.state === 'loading'
 
   useEffect(() => {
     const loading = navigation.state === 'loading'
+    loadingRef.current = loading
     if (barRef.current) {
       if (loading) {
         // instead of adding the `loading` class right when loading starts, set

--- a/app/components/Search.tsx
+++ b/app/components/Search.tsx
@@ -34,7 +34,7 @@ import type { RfdItem } from '~/services/rfd.server'
 import { formatRfdNum } from '~/utils/canonicalUrl'
 
 const Search = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
-  const searchClient = useRef<InstantMeiliSearchInstance>(null)
+  const [searchClient, setSearchClient] = useState<InstantMeiliSearchInstance | null>(null)
 
   useEffect(() => {
     const { searchClient: client } = instantMeiliSearch(
@@ -48,7 +48,7 @@ const Search = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
     // Additionally we are adding short circuiting logic so that we do not perform search requests
     // until N characters have been submitted
     // https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/#implementing-a-proxy
-    searchClient.current = {
+    const configuredClient = {
       ...client,
 
       // We cheat with the any type here so that we do not need to bother with the extensive fields
@@ -92,9 +92,12 @@ const Search = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
         })
       },
     }
+
+    const timeout = setTimeout(() => setSearchClient(configuredClient), 0)
+    return () => clearTimeout(timeout)
   }, [])
 
-  if (searchClient.current) {
+  if (searchClient) {
     return (
       <>
         <Dialog
@@ -104,7 +107,7 @@ const Search = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
           aria-label="Search"
           backdrop={<div className="backdrop" />}
         >
-          <InstantSearch searchClient={searchClient.current} indexName="rfd">
+          <InstantSearch searchClient={searchClient} indexName="rfd">
             <Configure attributesToSnippet={['content:15']} />
             <SearchWrapper
               dismissSearch={onClose}
@@ -125,11 +128,6 @@ const SearchWrapper = ({ dismissSearch }: { dismissSearch: () => void }) => {
   const { items, results } = useHits()
 
   const [selectedIdx, setSelectedIdx] = useState(0)
-
-  useEffect(() => {
-    // Whenever number of groups changes ensure the index is not more than that
-    setSelectedIdx((s) => (s > items.length ? items.length : s))
-  }, [items])
 
   // Remove items without content
   const hitsWithoutEmpty = items.filter((hit) => hit.content !== '')
@@ -157,6 +155,8 @@ const SearchWrapper = ({ dismissSearch }: { dismissSearch: () => void }) => {
     flattenedHits.push(...groupedHits[score[0]])
   })
 
+  const activeIdx = Math.min(selectedIdx, Math.max(flattenedHits.length - 1, 0))
+
   const noMatches =
     results &&
     results.query !== '' &&
@@ -169,18 +169,18 @@ const SearchWrapper = ({ dismissSearch }: { dismissSearch: () => void }) => {
       onKeyDown={(e) => {
         const lastIdx = hitsWithoutEmpty.length - 1
         if (e.key === 'Enter') {
-          const selectedItem = flattenedHits[selectedIdx]
+          const selectedItem = flattenedHits[activeIdx]
           if (!selectedItem) return
           navigate(`/rfd/${formatRfdNum(selectedItem.rfd_number)}#${selectedItem.anchor}`)
           // needed despite key={pathname + hash} logic in case we navigate
           // to the page we're already on
           dismissSearch()
         } else if (e.key === 'ArrowDown') {
-          const newIdx = selectedIdx < lastIdx ? selectedIdx + 1 : 0
+          const newIdx = activeIdx < lastIdx ? activeIdx + 1 : 0
           setSelectedIdx(newIdx)
           e.preventDefault() // Prevent it from moving input cursor
         } else if (e.key === 'ArrowUp') {
-          const newIdx = selectedIdx === 0 ? lastIdx : selectedIdx - 1
+          const newIdx = activeIdx === 0 ? lastIdx : activeIdx - 1
           setSelectedIdx(newIdx)
           e.preventDefault()
         }
@@ -225,7 +225,7 @@ const SearchWrapper = ({ dismissSearch }: { dismissSearch: () => void }) => {
               <SearchResponse
                 hasHits={items.length > 0}
                 hits={flattenedHits}
-                selectedIdx={selectedIdx}
+                selectedIdx={activeIdx}
               />
             )}
           </div>
@@ -327,8 +327,6 @@ const SearchResponse = ({
 }
 
 const Hits = ({ data, selectedIdx }: { data: RFDHit[]; selectedIdx: number }) => {
-  let prevRFD = -1
-
   const divRef = createRef<HTMLDivElement>()
   const ulRef = createRef<HTMLUListElement>()
 
@@ -341,9 +339,8 @@ const Hits = ({ data, selectedIdx }: { data: RFDHit[]; selectedIdx: number }) =>
     >
       <ul ref={ulRef}>
         {data.map((hit, index) => {
-          const isNewSection = hit.rfd_number !== prevRFD
+          const isNewSection = index === 0 || hit.rfd_number !== data[index - 1].rfd_number
           const sectionIsSelected = data[selectedIdx].rfd_number === hit.rfd_number
-          prevRFD = hit.rfd_number
 
           return (
             <Fragment key={hit.objectID}>

--- a/app/components/SelectRfdCombobox.tsx
+++ b/app/components/SelectRfdCombobox.tsx
@@ -288,12 +288,11 @@ const ComboboxItem = memo(
     // Only if the user has typed something, with a timeout to
     // avoid prefetching everything
     useEffect(() => {
-      if (selected && isDirty) {
-        timer.current = setTimeout(() => setShouldPrefetch(true), 250)
-      } else {
-        clear()
-        setShouldPrefetch(false)
-      }
+      const shouldEnable = selected && isDirty
+      timer.current = setTimeout(
+        () => setShouldPrefetch(shouldEnable),
+        shouldEnable ? 250 : 0,
+      )
 
       return clear
     }, [selected, isDirty])

--- a/app/components/home/FilterDropdown.tsx
+++ b/app/components/home/FilterDropdown.tsx
@@ -95,8 +95,7 @@ const FilterDropdown = () => {
   const rfdsFilteredByStates = useMemo(() => {
     const allowed = new Set(effectiveStates)
     return rfds.filter((rfd) => rfd.state !== null && allowed.has(rfd.state))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rfds, effectiveStates.join(',')])
+  }, [rfds, effectiveStates])
 
   const intersect = <T,>(a: T[], b: T[]) => {
     const setB = new Set(b)

--- a/app/components/rfd/RfdInlineComments.tsx
+++ b/app/components/rfd/RfdInlineComments.tsx
@@ -140,13 +140,18 @@ const RfdInlineComments = ({ pullNumber }: { pullNumber: number }) => {
       })
     })
 
-    // Group comments by block
-    // in_reply_to_id
-    setInlineComments(newComments)
+    // Group comments by block. Defer the state updates so the effect only
+    // synchronizes with the rendered document and does not cascade renders.
+    const commentsTimeout = setTimeout(() => {
+      setInlineComments(newComments)
+      setIsLoaded(false)
+    }, 0)
+    const loadedTimeout = setTimeout(() => setIsLoaded(true), 50)
 
-    setTimeout(() => {
-      setIsLoaded(true)
-    }, 50)
+    return () => {
+      clearTimeout(commentsTimeout)
+      clearTimeout(loadedTimeout)
+    }
   }, [discussion?.comments])
 
   if (!inlineComments) return null

--- a/app/components/rfd/RfdPreview.tsx
+++ b/app/components/rfd/RfdPreview.tsx
@@ -55,6 +55,7 @@ export function calcOffset(element: HTMLAnchorElement | HTMLElement) {
 }
 
 interface RfdPreviewState {
+  sourceRfd: number
   rfd: RfdListItem
   position: { left: number; top: number }
   anchor: HTMLAnchorElement
@@ -81,9 +82,7 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
     }
   }, [])
 
-  useEffect(() => {
-    setPreview(null)
-  }, [currentRfd])
+  const activePreview = preview?.sourceRfd === currentRfd ? preview : null
 
   // Based on https://github.com/remix-run/react-router-website/blob/main/app/ui/delegate-markdown-links.ts
   // Converts regular AsciiDoc a tags and makes them React Routery
@@ -142,6 +141,7 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
       timeoutRef.current = setTimeout(() => {
         const offset = calcOffset(anchor)
         setPreview({
+          sourceRfd: currentRfd,
           rfd: matchedRfd,
           position: offset,
           anchor,
@@ -172,7 +172,7 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
   }, [navigate, nodeRef, currentRfd, rfds, clearHoverTimeout, isNavigating])
 
   useEffect(() => {
-    if (!preview) return
+    if (!activePreview) return
 
     type Point = [number, number]
     type Polygon = Point[]
@@ -231,7 +231,7 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
 
       const cursor: Point = [event.clientX, event.clientY]
       const floatingRect = previewRef.current.getBoundingClientRect()
-      const anchorRect = preview.anchor.getBoundingClientRect()
+      const anchorRect = activePreview.anchor.getBoundingClientRect()
 
       const polygon = getPolygon(anchorRect, floatingRect)
       const isInside = isPointInPolygon(cursor, polygon)
@@ -243,18 +243,18 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
 
     window.addEventListener('mousemove', handleMouseMove)
     return () => window.removeEventListener('mousemove', handleMouseMove)
-  }, [preview])
+  }, [activePreview])
 
-  if (!preview) return null
+  if (!activePreview) return null
 
-  const { title, number, state, latestMajorChangeAt, formattedNumber } = preview.rfd
-  const authors = preview.rfd.authors || []
+  const { title, number, state, latestMajorChangeAt, formattedNumber } = activePreview.rfd
+  const authors = activePreview.rfd.authors || []
 
   return (
     <div
       ref={previewRef}
       className="shadow-tooltip bg-raise absolute z-10 mt-8 flex w-[24rem] rounded-lg p-3"
-      style={{ top: preview.position.top, left: preview.position.left }}
+      style={{ top: activePreview.position.top, left: activePreview.position.left }}
     >
       <Link
         prefetch="intent"

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -50,6 +50,8 @@ import { parseRfdNum } from '~/utils/parseRfdNum'
 import { filterRfds } from '~/utils/rfdSearch'
 import { parseSortOrder, type SortAttr } from '~/utils/rfdSortOrder.server'
 
+const UNDATED_SORT_VALUE = Number.MAX_SAFE_INTEGER
+
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const cookieHeader = request.headers.get('Cookie')
   return parseSortOrder(await rfdSortCookie.parse(cookieHeader))
@@ -134,7 +136,6 @@ export default function Index() {
 
   const [matchedItems, exactMatch] = useMemo(() => {
     const parsedInput = parseRfdNum(input.trim())
-    const now = Date.now()
 
     if (!input.trim()) {
       const sortedRfds = sortBy(rfds, (rfd) => {
@@ -143,7 +144,7 @@ export default function Index() {
             ? rfd.number
             : rfd.latestMajorChangeAt
               ? rfd.latestMajorChangeAt.getTime()
-              : now
+              : UNDATED_SORT_VALUE
         const mult = sortDir === 'asc' ? 1 : -1
         return sortVal * mult
       })
@@ -161,7 +162,7 @@ export default function Index() {
           ? rfd.number
           : rfd.latestMajorChangeAt
             ? rfd.latestMajorChangeAt.getTime()
-            : now
+            : UNDATED_SORT_VALUE
       const mult = sortDir === 'asc' ? 1 : -1
       return sortVal * mult
     })
@@ -245,7 +246,8 @@ export default function Index() {
     // instead of a callback because it should only happen after the nav,
     // otherwise we get a flash of the unfiltered list.
     if (state && state.shouldClearInput) {
-      setInput('')
+      const timeout = setTimeout(() => setInput(''), 0)
+      return () => clearTimeout(timeout)
     }
   }, [state])
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,7 @@ export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   jsxA11y.flatConfigs.recommended,
-  reactHooks.configs['recommended-latest'],
+  reactHooks.configs.flat['recommended-latest'],
   {
     ...playwright.configs['flat/recommended'],
     files: ['test/e2e/**'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "rfd-site",
       "dependencies": {
         "@ariakit/react": "^0.4.18",
         "@asciidoctor/core": "^3.0.4",
         "@base-ui/react": "^1.2.0",
-        "@eslint/compat": "^1.4.0",
+        "@eslint/compat": "^2.1.0",
         "@floating-ui/react": "^0.17.0",
         "@leeoniya/ufuzzy": "^1.0.19",
         "@meilisearch/instant-meilisearch": "^0.28.0",
@@ -52,7 +51,8 @@
       },
       "devDependencies": {
         "@csstools/postcss-global-data": "^3.1.0",
-        "@eslint/compat": "^1.4.0",
+        "@eslint/compat": "^2.1.0",
+        "@eslint/js": "^9.39.5",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@playwright/test": "^1.55.1",
         "@react-router/dev": "^7.17.0",
@@ -70,10 +70,10 @@
         "@types/react-instantsearch-dom": "^6.12.9",
         "autoprefixer": "^10.4.21",
         "cssnano": "^7.1.1",
-        "eslint": "^9.36.0",
+        "eslint": "^9.39.5",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-playwright": "^2.2.2",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-playwright": "^2.11.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "instantsearch.js": "^4.80.0",
         "postcss": "^8.5.6",
         "postcss-import": "^16.1.1",
@@ -81,13 +81,13 @@
         "postcss-value-parser": "^4.2.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^4.2.2",
-        "typescript": "~5.9.2",
-        "typescript-eslint": "^8.44.1",
+        "typescript": "~6.0.3",
+        "typescript-eslint": "^8.65.0",
         "vite": "^8.0.9",
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
@@ -1414,19 +1414,19 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
-      "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^8.40 || 9"
+        "eslint": "^8.40 || 9 || 10"
       },
       "peerDependenciesMeta": {
         "eslint": {
@@ -1450,9 +1450,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1486,7 +1486,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
+    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
@@ -1499,10 +1499,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,7 +1525,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -1524,9 +1537,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1541,9 +1554,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1572,9 +1585,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1603,6 +1616,19 @@
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4654,17 +4680,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4677,15 +4703,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4693,16 +4719,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4718,14 +4744,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4740,14 +4766,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4758,9 +4784,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4775,15 +4801,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4800,9 +4826,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4814,16 +4840,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4852,26 +4878,26 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4881,16 +4907,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4905,13 +4931,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4920,19 +4946,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -7330,9 +7343,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7341,8 +7354,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -7444,9 +7457,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.2.tgz",
-      "integrity": "sha512-0N+2OWc3NZbOZ0gK8mp2TK6Qu3UWcJTQ9rqU0UM2yRJXgT758pvpY0lsOLIySfbyFrLqn3TcXjixbmcK90VnuQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.11.0.tgz",
+      "integrity": "sha512-zOIEYyv1TSn2izXkyg/yj0LXc4YBQI6pl3xIFWwMCcXt/dgQCz8dBqXiXFMoM3xc/GqZThAtaGYo8aPu/vBd+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7473,16 +7486,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -7503,16 +7523,29 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -7533,14 +7566,27 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -7574,6 +7620,19 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.1"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -8375,6 +8434,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -9104,9 +9180,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -12793,9 +12869,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -12807,16 +12883,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13572,6 +13648,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ariakit/react": "^0.4.18",
     "@asciidoctor/core": "^3.0.4",
     "@base-ui/react": "^1.2.0",
-    "@eslint/compat": "^1.4.0",
+    "@eslint/compat": "^2.1.0",
     "@floating-ui/react": "^0.17.0",
     "@leeoniya/ufuzzy": "^1.0.19",
     "@meilisearch/instant-meilisearch": "^0.28.0",
@@ -62,7 +62,8 @@
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "^3.1.0",
-    "@eslint/compat": "^1.4.0",
+    "@eslint/compat": "^2.1.0",
+    "@eslint/js": "^9.39.5",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@playwright/test": "^1.55.1",
     "@react-router/dev": "^7.17.0",
@@ -80,10 +81,10 @@
     "@types/react-instantsearch-dom": "^6.12.9",
     "autoprefixer": "^10.4.21",
     "cssnano": "^7.1.1",
-    "eslint": "^9.36.0",
+    "eslint": "^9.39.5",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-playwright": "^2.2.2",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-playwright": "^2.11.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "instantsearch.js": "^4.80.0",
     "postcss": "^8.5.6",
     "postcss-import": "^16.1.1",
@@ -91,13 +92,13 @@
     "postcss-value-parser": "^4.2.0",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4.2.2",
-    "typescript": "~5.9.2",
-    "typescript-eslint": "^8.44.1",
+    "typescript": "~6.0.3",
+    "typescript-eslint": "^8.65.0",
     "vite": "^8.0.9",
     "vitest": "^4.1.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "overrides": {
     "algoliasearch": "^4.24.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "strict": true,
     "allowJs": false,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },


### PR DESCRIPTION
Bump to Node 24.
Bump to Typescript 6
Bump ESlint (eslint-plugin-jsx-a11y blocks 10.x upgrade)
Fix for new lints.

| package                   | old     | new     |
| ------------------------- | ------- | ------- |
| eslint                    | ^9.36.0 | ^9.39.5 |
| eslint-plugin-playwright  | ^2.2.2  | ^2.11.0 |
| eslint-plugin-react-hooks | ^5.2.0  | ^7.1.1  |
| @eslint/compat            | ^1.4.0  | ^2.1.0  |
| @eslint/js                | —       | ^9.39.5 |
| typescript                | ~5.9.2  | ~6.0.3  |
| typescript-eslint         | ^8.44.1 | ^8.65.0 |
| Node.js engine            | >=22    | >=24    |
