### PR TITLE
Remove unnecessary cookie signing secrets

### DIFF
--- a/app/services/cookies.server.ts
+++ b/app/services/cookies.server.ts
@@ -12,7 +12,6 @@ export const returnToCookie = createCookie('_return_to', {
   sameSite: 'lax',
   path: '/',
   httpOnly: true,
-  secrets: ['s3cr3t'],
   maxAge: 60 * 10, // 10 minutes
   secure: process.env.NODE_ENV === 'production',
 })
@@ -28,7 +27,6 @@ export const inlineCommentsCookie = createCookie('_inline_comments', {
   sameSite: 'lax',
   path: '/',
   httpOnly: true,
-  secrets: ['s3cr3t'],
   secure: process.env.NODE_ENV === 'production',
   maxAge: 60 * 60 * 24 * 365, // Keep cookie for a year
 })


### PR DESCRIPTION
These auxiliary cookies for returnTo and inline comments have hardcoded secrets, which are pointless. Adding real secrets for them is pointless because forging the cookies can't get an attacker anything.

https://reactrouter.com/explanation/sessions-and-cookies#signing-cookies

The session cookie has a proper secret.

https://github.com/oxidecomputer/rfd-site/blob/b30f8dbfb6f79669b3f0e56b60ffb64816629281/app/services/session.server.ts?plain=1#L32-L42