### PR TITLE
Improve navigation for screen readers

### DIFF
--- a/app/components/RouteAnnouncer.tsx
+++ b/app/components/RouteAnnouncer.tsx
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router'
+
+/**
+ * A real page load tells a screen reader where it landed: the new page gets
+ * announced and the reading position goes back to the top. A client-side nav
+ * does neither — React Router swaps the DOM in place and focus stays on the
+ * link that was clicked, which usually isn't in the document anymore. Next.js
+ * ships a route announcer for this; React Router leaves it to the app.
+ *
+ * So on every page change we do it ourselves: announce the new page in a
+ * visually hidden live region, and move focus to the top of the content, which
+ * is where the skip link points too. Gatsby's user testing with screen reader
+ * users recommends this announce + move-focus combination:
+ * https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
+ * https://github.com/vercel/next.js/blob/08b1916/packages/next/src/client/route-announcer.tsx
+ */
+const RouteAnnouncer = () => {
+  const { pathname, hash } = useLocation()
+  const [announcement, setAnnouncement] = useState('')
+  // no announcement on initial load — the real page load announces itself
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+
+    // <Meta> has already rendered the new title by the time effects run. Commas
+    // instead of pipes so a screen reader reads it as a phrase — "68 -
+    // Partnership as Shared Values, RFD, Oxide" — rather than reading out the
+    // punctuation.
+    setAnnouncement(document.title.split(' | ').join(', '))
+
+    // Two cases where the destination is a better judge of the reading position
+    // than we are: the index page focuses its filter input on mount, and an
+    // anchor nav (from a search result, say) asked for a specific section.
+    //
+    // Both are decided from the location rather than from document.activeElement
+    // — "focus is still on the body, so the thing that had it unmounted" reads
+    // like the obvious test but isn't reliable. Browsers disagree (Safari
+    // doesn't focus links on click, so after a link click focus is on the link
+    // in Firefox but on the body in Safari), and mid-navigation the outgoing
+    // page's #content can still be in the document alongside the new one.
+    if (pathname === '/' || hash) return
+
+    // Prefer the page's h1 over <main>. VoiceOver reads a focused heading's
+    // text, whereas focusing a big landmark container just gets "main" with no
+    // content. The h1 also remounts on every page change, while <main> persists
+    // across navs — refocusing an already-focused element is a no-op that fires
+    // no event, so the VO cursor would never move after the first nav. Focusing
+    // the destination page's heading is the standard recommendation for SPA
+    // route changes: https://www.deque.com/blog/single-page-apps-focus-management/
+    //
+    // preventScroll because scroll position is <ScrollRestoration />'s job:
+    // without it, focusing the top of the page clobbers the restored position
+    // on back/forward nav.
+    const main = document.getElementById('content')
+    const heading = main?.querySelector('h1')
+    if (heading) {
+      heading.tabIndex = -1 // headings aren't focusable by default
+      // Safari (unlike Chrome/FF) matches :focus-visible on programmatic focus
+      // even when the nav came from a click. The heading isn't interactive, so
+      // never show a ring.
+      heading.classList.add('outline-none')
+    }
+    ;(heading || main)?.focus({ preventScroll: true })
+  }, [pathname, hash])
+
+  return (
+    <p aria-live="assertive" role="alert" data-testid="route-announcer" className="sr-only">
+      {announcement}
+    </p>
+  )
+}
+
+export default RouteAnnouncer

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -153,19 +153,17 @@ const RouteAnnouncer = () => {
     // punctuation.
     setAnnouncement(document.title.split(' | ').join(', '))
 
-    const main = document.getElementById('content')
-
-    // Two cases where we're not the best judge of the reading position:
+    // Two cases where the destination is a better judge of the reading position
+    // than we are: the index page focuses its filter input on mount, and an
+    // anchor nav (from a search result, say) asked for a specific section.
     //
-    // - The destination route has already put focus inside the new content (the
-    //   index page focuses its filter input on mount). Checking for focus
-    //   inside #content rather than `activeElement === document.body` because
-    //   the latter varies by browser: Safari doesn't focus links on click, so
-    //   after a link click focus is on the link in Firefox but on the body in
-    //   Safari.
-    // - The nav targets an anchor, e.g. from a search result. The browser jump
-    //   to that heading is where the user asked to be.
-    if (hash || main?.contains(document.activeElement)) return
+    // Both are decided from the location rather than from document.activeElement
+    // — "focus is still on the body, so the thing that had it unmounted" reads
+    // like the obvious test but isn't reliable. Browsers disagree (Safari
+    // doesn't focus links on click, so after a link click focus is on the link
+    // in Firefox but on the body in Safari), and mid-navigation the outgoing
+    // page's #content can still be in the document alongside the new one.
+    if (pathname === '/' || hash) return
 
     // Prefer the page's h1 over <main>. VoiceOver reads a focused heading's
     // text, whereas focusing a big landmark container just gets "main" with no
@@ -178,6 +176,7 @@ const RouteAnnouncer = () => {
     // preventScroll because scroll position is <ScrollRestoration />'s job:
     // without it, focusing the top of the page clobbers the restored position
     // on back/forward nav.
+    const main = document.getElementById('content')
     const heading = main?.querySelector('h1')
     if (heading) {
       heading.tabIndex = -1 // headings aren't focusable by default
@@ -242,8 +241,6 @@ export default function App() {
           </div>
         )}
       </QueryClientProvider>
-      {/* after the outlet so a route that focuses something on mount (the index
-          page's filter input) has already done it when the announcer checks */}
       <RouteAnnouncer />
     </Layout>
   )

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,7 +7,6 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
 import {
   isRouteErrorResponse,
   Links,
@@ -16,7 +15,6 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-  useLocation,
   useRouteError,
   useRouteLoaderData,
   type LinksFunction,
@@ -29,6 +27,7 @@ import {
 import styles from '~/styles/index.css?url'
 
 import LoadingBar from './components/LoadingBar'
+import RouteAnnouncer from './components/RouteAnnouncer'
 import { authenticate, logoutOnAuthError } from './services/auth.server'
 import { inlineCommentsCookie } from './services/cookies.server'
 import { isLocalMode } from './services/rfd.local.server'
@@ -120,80 +119,6 @@ const queryClient = new QueryClient()
 // Set theme before first paint to prevent flash of wrong color scheme.
 // Mirrors logic in app/stores/theme.ts — must stay in sync.
 const themeInitScript = `(function(){try{var p=localStorage.getItem('theme-preference');if(p!=='dark'&&p!=='light'&&p!=='system')p='dark';var r=p==='system'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):p;document.documentElement.dataset.theme=r;}catch(_){document.documentElement.dataset.theme='dark';}})();`
-
-/**
- * A real page load tells a screen reader where it landed: the new page gets
- * announced and the reading position goes back to the top. A client-side nav
- * does neither — React Router swaps the DOM in place and focus stays on the
- * link that was clicked, which usually isn't in the document anymore. Next.js
- * ships a route announcer for this; React Router leaves it to the app.
- *
- * So on every page change we do it ourselves: announce the new page in a
- * visually hidden live region, and move focus to the top of the content, which
- * is where the skip link points too. Gatsby's user testing with screen reader
- * users recommends this announce + move-focus combination:
- * https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
- * https://github.com/vercel/next.js/blob/08b1916/packages/next/src/client/route-announcer.tsx
- */
-const RouteAnnouncer = () => {
-  const { pathname, hash } = useLocation()
-  const [announcement, setAnnouncement] = useState('')
-  // no announcement on initial load — the real page load announces itself
-  const isFirstRender = useRef(true)
-
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
-
-    // <Meta> has already rendered the new title by the time effects run. Commas
-    // instead of pipes so a screen reader reads it as a phrase — "68 -
-    // Partnership as Shared Values, RFD, Oxide" — rather than reading out the
-    // punctuation.
-    setAnnouncement(document.title.split(' | ').join(', '))
-
-    // Two cases where the destination is a better judge of the reading position
-    // than we are: the index page focuses its filter input on mount, and an
-    // anchor nav (from a search result, say) asked for a specific section.
-    //
-    // Both are decided from the location rather than from document.activeElement
-    // — "focus is still on the body, so the thing that had it unmounted" reads
-    // like the obvious test but isn't reliable. Browsers disagree (Safari
-    // doesn't focus links on click, so after a link click focus is on the link
-    // in Firefox but on the body in Safari), and mid-navigation the outgoing
-    // page's #content can still be in the document alongside the new one.
-    if (pathname === '/' || hash) return
-
-    // Prefer the page's h1 over <main>. VoiceOver reads a focused heading's
-    // text, whereas focusing a big landmark container just gets "main" with no
-    // content. The h1 also remounts on every page change, while <main> persists
-    // across navs — refocusing an already-focused element is a no-op that fires
-    // no event, so the VO cursor would never move after the first nav. Focusing
-    // the destination page's heading is the standard recommendation for SPA
-    // route changes: https://www.deque.com/blog/single-page-apps-focus-management/
-    //
-    // preventScroll because scroll position is <ScrollRestoration />'s job:
-    // without it, focusing the top of the page clobbers the restored position
-    // on back/forward nav.
-    const main = document.getElementById('content')
-    const heading = main?.querySelector('h1')
-    if (heading) {
-      heading.tabIndex = -1 // headings aren't focusable by default
-      // Safari (unlike Chrome/FF) matches :focus-visible on programmatic focus
-      // even when the nav came from a click. The heading isn't interactive, so
-      // never show a ring.
-      heading.classList.add('outline-none')
-    }
-    ;(heading || main)?.focus({ preventScroll: true })
-  }, [pathname, hash])
-
-  return (
-    <p aria-live="assertive" role="alert" data-testid="route-announcer" className="sr-only">
-      {announcement}
-    </p>
-  )
-}
 
 const Layout = ({ children }: { children: React.ReactNode }) => (
   <html lang="en" suppressHydrationWarning>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
 import {
   isRouteErrorResponse,
   Links,
@@ -15,6 +16,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useLocation,
   useRouteError,
   useRouteLoaderData,
   type LinksFunction,
@@ -114,6 +116,46 @@ const queryClient = new QueryClient()
 // Mirrors logic in app/stores/theme.ts — must stay in sync.
 const themeInitScript = `(function(){try{var p=localStorage.getItem('theme-preference');if(p!=='dark'&&p!=='light'&&p!=='system')p='dark';var r=p==='system'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):p;document.documentElement.dataset.theme=r;}catch(_){document.documentElement.dataset.theme='dark';}})();`
 
+/**
+ * Client-side route transitions don't give screen readers the feedback a real
+ * page load does: nothing is announced and focus is left wherever it was. After
+ * each navigation, announce the new page title in a visually hidden live region
+ * (the same approach as Next.js's built-in route announcer). If focus fell back
+ * to <body> because the element that had it unmounted, move it to the content
+ * wrapper so the reading position starts at the top of the new page; routes
+ * that set their own focus (like the index filter input) are left alone.
+ *
+ * The announce + move-focus combination follows Gatsby's user testing with
+ * screen reader users:
+ * https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
+ * Next.js's built-in announcer implements the same thing:
+ * https://github.com/vercel/next.js/blob/08b1916/packages/next/src/client/route-announcer.tsx
+ */
+const RouteAnnouncer = () => {
+  const { pathname } = useLocation()
+  const [announcement, setAnnouncement] = useState('')
+  // no announcement on initial load — the real page load announces itself
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    // <Meta> has already rendered the new title by the time effects run
+    setAnnouncement(document.title)
+    if (document.activeElement === document.body) {
+      document.querySelector<HTMLElement>('.root')?.focus()
+    }
+  }, [pathname])
+
+  return (
+    <p aria-live="assertive" role="alert" data-testid="route-announcer" className="sr-only">
+      {announcement}
+    </p>
+  )
+}
+
 const Layout = ({ children }: { children: React.ReactNode }) => (
   <html lang="en" suppressHydrationWarning>
     <head>
@@ -132,7 +174,10 @@ const Layout = ({ children }: { children: React.ReactNode }) => (
       )}
     </head>
     <body className="mb-32">
-      <div className="root">{children}</div>
+      {/* focus target for RouteAnnouncer, hence tabIndex and outline-none */}
+      <div className="root outline-none" tabIndex={-1}>
+        {children}
+      </div>
       <ScrollRestoration />
       <Scripts />
     </body>
@@ -154,6 +199,9 @@ export default function App() {
           </div>
         )}
       </QueryClientProvider>
+      {/* placed after the outlet so route effects (e.g. the index page focusing
+          its filter input) run before the announcer's focus fallback */}
+      <RouteAnnouncer />
     </Layout>
   )
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -104,9 +104,14 @@ export function ErrorBoundary() {
 
   return (
     <Layout>
-      <div className="flex h-full w-full items-center justify-center">
+      {/* id and tabIndex make this the skip link and route announcer target */}
+      <main
+        id="content"
+        tabIndex={-1}
+        className="flex h-full w-full items-center justify-center outline-none"
+      >
         <h1 className="text-2xl">{message}</h1>
-      </div>
+      </main>
     </Layout>
   )
 }
@@ -117,22 +122,21 @@ const queryClient = new QueryClient()
 const themeInitScript = `(function(){try{var p=localStorage.getItem('theme-preference');if(p!=='dark'&&p!=='light'&&p!=='system')p='dark';var r=p==='system'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):p;document.documentElement.dataset.theme=r;}catch(_){document.documentElement.dataset.theme='dark';}})();`
 
 /**
- * Client-side route transitions don't give screen readers the feedback a real
- * page load does: nothing is announced and focus is left wherever it was. After
- * each navigation, announce the new page title in a visually hidden live region
- * (the same approach as Next.js's built-in route announcer). If focus fell back
- * to <body> because the element that had it unmounted, move it to the content
- * wrapper so the reading position starts at the top of the new page; routes
- * that set their own focus (like the index filter input) are left alone.
+ * A real page load tells a screen reader where it landed: the new page gets
+ * announced and the reading position goes back to the top. A client-side nav
+ * does neither — React Router swaps the DOM in place and focus stays on the
+ * link that was clicked, which usually isn't in the document anymore. Next.js
+ * ships a route announcer for this; React Router leaves it to the app.
  *
- * The announce + move-focus combination follows Gatsby's user testing with
- * screen reader users:
+ * So on every page change we do it ourselves: announce the new page in a
+ * visually hidden live region, and move focus to the top of the content, which
+ * is where the skip link points too. Gatsby's user testing with screen reader
+ * users recommends this announce + move-focus combination:
  * https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
- * Next.js's built-in announcer implements the same thing:
  * https://github.com/vercel/next.js/blob/08b1916/packages/next/src/client/route-announcer.tsx
  */
 const RouteAnnouncer = () => {
-  const { pathname } = useLocation()
+  const { pathname, hash } = useLocation()
   const [announcement, setAnnouncement] = useState('')
   // no announcement on initial load — the real page load announces itself
   const isFirstRender = useRef(true)
@@ -142,12 +146,48 @@ const RouteAnnouncer = () => {
       isFirstRender.current = false
       return
     }
-    // <Meta> has already rendered the new title by the time effects run
-    setAnnouncement(document.title)
-    if (document.activeElement === document.body) {
-      document.querySelector<HTMLElement>('.root')?.focus()
+
+    // <Meta> has already rendered the new title by the time effects run. Commas
+    // instead of pipes so a screen reader reads it as a phrase — "68 -
+    // Partnership as Shared Values, RFD, Oxide" — rather than reading out the
+    // punctuation.
+    setAnnouncement(document.title.split(' | ').join(', '))
+
+    const main = document.getElementById('content')
+
+    // Two cases where we're not the best judge of the reading position:
+    //
+    // - The destination route has already put focus inside the new content (the
+    //   index page focuses its filter input on mount). Checking for focus
+    //   inside #content rather than `activeElement === document.body` because
+    //   the latter varies by browser: Safari doesn't focus links on click, so
+    //   after a link click focus is on the link in Firefox but on the body in
+    //   Safari.
+    // - The nav targets an anchor, e.g. from a search result. The browser jump
+    //   to that heading is where the user asked to be.
+    if (hash || main?.contains(document.activeElement)) return
+
+    // Prefer the page's h1 over <main>. VoiceOver reads a focused heading's
+    // text, whereas focusing a big landmark container just gets "main" with no
+    // content. The h1 also remounts on every page change, while <main> persists
+    // across navs — refocusing an already-focused element is a no-op that fires
+    // no event, so the VO cursor would never move after the first nav. Focusing
+    // the destination page's heading is the standard recommendation for SPA
+    // route changes: https://www.deque.com/blog/single-page-apps-focus-management/
+    //
+    // preventScroll because scroll position is <ScrollRestoration />'s job:
+    // without it, focusing the top of the page clobbers the restored position
+    // on back/forward nav.
+    const heading = main?.querySelector('h1')
+    if (heading) {
+      heading.tabIndex = -1 // headings aren't focusable by default
+      // Safari (unlike Chrome/FF) matches :focus-visible on programmatic focus
+      // even when the nav came from a click. The heading isn't interactive, so
+      // never show a ring.
+      heading.classList.add('outline-none')
     }
-  }, [pathname])
+    ;(heading || main)?.focus({ preventScroll: true })
+  }, [pathname, hash])
 
   return (
     <p aria-live="assertive" role="alert" data-testid="route-announcer" className="sr-only">
@@ -180,10 +220,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => (
       >
         Skip to content
       </a>
-      {/* focus target for RouteAnnouncer, hence tabIndex and outline-none */}
-      <div className="root outline-none" tabIndex={-1}>
-        {children}
-      </div>
+      <div className="root">{children}</div>
       <ScrollRestoration />
       <Scripts />
     </body>
@@ -205,8 +242,8 @@ export default function App() {
           </div>
         )}
       </QueryClientProvider>
-      {/* placed after the outlet so route effects (e.g. the index page focusing
-          its filter input) run before the announcer's focus fallback */}
+      {/* after the outlet so a route that focuses something on mount (the index
+          page's filter input) has already done it when the announcer checks */}
       <RouteAnnouncer />
     </Layout>
   )

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -174,6 +174,12 @@ const Layout = ({ children }: { children: React.ReactNode }) => (
       )}
     </head>
     <body className="mb-32">
+      <a
+        href="#content"
+        className="text-sans-md text-raise bg-tertiary sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:p-3"
+      >
+        Skip to content
+      </a>
       {/* focus target for RouteAnnouncer, hence tabIndex and outline-none */}
       <div className="root outline-none" tabIndex={-1}>
         {children}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -273,7 +273,8 @@ export default function Index() {
     <>
       {/* key makes the search dialog close on selection */}
       <Header key={pathname + hash} />
-      <div className="pt-4 pb-12">
+      {/* id and tabIndex let the skip link in root.tsx target and focus it */}
+      <main id="content" tabIndex={-1} className="pt-4 pb-12 outline-none">
         <Container>
           <div className="600:pt-[calc(299/1200*100%)] max-600:my-4 relative w-full">
             <img
@@ -396,7 +397,7 @@ export default function Index() {
             </div>
           </Container>
         )}
-      </div>
+      </main>
     </>
   )
 }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -113,7 +113,12 @@ export default function Login() {
 
         <div className="border-t-secondary absolute bottom-0 h-(--header-height) w-full border-t"></div>
       </div>
-      <div className="shadow-modal bg-raise 600:w-[24rem] fixed top-1/2 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2 -translate-y-1/2 space-y-3 rounded-lg p-6 text-center transition-all">
+      {/* id and tabIndex make this the skip link and route announcer target */}
+      <main
+        id="content"
+        tabIndex={-1}
+        className="shadow-modal bg-raise 600:w-[24rem] fixed top-1/2 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2 -translate-y-1/2 space-y-3 rounded-lg p-6 text-center transition-all outline-none"
+      >
         {!showEmailForm && (
           <>
             <h1 className="text-sans-2xl light:text-default text-accent mb-8">Sign in</h1>
@@ -172,7 +177,7 @@ export default function Login() {
             </div>
           </>
         )}
-      </div>
+      </main>
     </>
   )
 }

--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -231,7 +231,12 @@ export default function Rfd() {
     <div ref={containerRef}>
       {/* key makes the search dialog close on selection */}
       <Header currentRfd={rfd} key={pathname + hash} />
-      <main className="800:mt-16 relative mt-12 pb-20 print:mt-0">
+      {/* id and tabIndex let the skip link in root.tsx target and focus it */}
+      <main
+        id="content"
+        tabIndex={-1}
+        className="800:mt-16 relative mt-12 pb-20 outline-none print:mt-0"
+      >
         {inlineComments && user && pullNumber && (
           <RfdInlineComments pullNumber={pullNumber} />
         )}

--- a/test/e2e/everything.spec.ts
+++ b/test/e2e/everything.spec.ts
@@ -414,3 +414,32 @@ test.describe('Accessible client-side navigation', () => {
     await expect(page.getByPlaceholder('Filter by')).toBeFocused()
   })
 })
+
+test.describe('Skip link and landmarks', () => {
+  test('skip link is first focusable on RFD page and focuses main', async ({ page }) => {
+    await page.goto('/rfd/0068')
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+
+    const skipLink = page.getByRole('link', { name: 'Skip to content' })
+    // visually hidden until focused, and first in tab order
+    await expect(skipLink).not.toBeInViewport()
+    await page.keyboard.press('Tab')
+    await expect(skipLink).toBeFocused()
+    await expect(skipLink).toBeInViewport()
+
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('main')).toBeFocused()
+  })
+
+  test('homepage has a main landmark and working skip link', async ({ page }) => {
+    await gotoHome(page)
+    await expect(page.getByRole('main')).toBeVisible()
+
+    // the filter input steals autofocus on the homepage, so focus the skip
+    // link directly rather than tabbing to it
+    const skipLink = page.getByRole('link', { name: 'Skip to content' })
+    await skipLink.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('main')).toBeFocused()
+  })
+})

--- a/test/e2e/everything.spec.ts
+++ b/test/e2e/everything.spec.ts
@@ -384,3 +384,33 @@ test.describe('Search', () => {
     ).toBeVisible()
   })
 })
+
+test.describe('Accessible client-side navigation', () => {
+  test('route change is announced and focus moves to content', async ({ page }) => {
+    await gotoHome(page)
+
+    // The route announcer live region is present but empty on initial load —
+    // a real page load announces itself, so announcing again would be noise.
+    const announcer = page.getByTestId('route-announcer')
+    await expect(announcer).toHaveText('')
+
+    // Client-side navigate to a known public RFD from the index
+    await page.getByPlaceholder('Filter by').fill('Partnership as Shared Values')
+    await page.getByRole('link', { name: 'Partnership as Shared Values' }).click()
+    await expectRfdPage(page, 'Partnership as Shared Values', 'Bryan Cantrill')
+
+    // The new page title is announced to screen readers...
+    await expect(announcer).toHaveText('68 - Partnership as Shared Values | RFD | Oxide')
+
+    // ...and focus, dropped on <body> when the clicked link unmounted, is
+    // moved to the content wrapper so the reading position starts at the top
+    // of the new page, like a real page load.
+    await expect(page.locator('.root')).toBeFocused()
+
+    // Navigating back to the index announces again, but does not steal focus:
+    // the filter input's own autofocus wins.
+    await page.getByRole('link', { name: 'Back to index' }).click()
+    await expect(announcer).toHaveText('RFD | Oxide')
+    await expect(page.getByPlaceholder('Filter by')).toBeFocused()
+  })
+})

--- a/test/e2e/everything.spec.ts
+++ b/test/e2e/everything.spec.ts
@@ -20,6 +20,8 @@ async function expectRfdPage(page: Page, title: string, author: string) {
 // render from `useDeferredValue` / `startTransition`.
 const rfdCountLocator = (page: Page) => page.getByTestId('rfd-count')
 
+const announcer = (page: Page) => page.getByTestId('route-announcer')
+
 async function rfdCount(page: Page): Promise<number> {
   const text = await rfdCountLocator(page).textContent()
   return Number(text?.trim() ?? '0')
@@ -382,36 +384,62 @@ test.describe('Search', () => {
     await expect(
       page.getByRole('heading', { name: 'Architectures', level: 2 }),
     ).toBeVisible()
+
+    // The nav is announced, but because it targets an anchor the route
+    // announcer leaves focus and scroll alone: the user asked for this section,
+    // so dragging focus up to the h1 would undo the jump to it.
+    await expect(announcer(page)).toHaveText('223 - Web Console Architecture, RFD, Oxide')
+    await expect(page.getByRole('heading', { level: 1 })).not.toBeFocused()
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
   })
 })
 
 test.describe('Accessible client-side navigation', () => {
-  test('route change is announced and focus moves to content', async ({ page }) => {
+  test('route change is announced and focus moves to the heading', async ({ page }) => {
     await gotoHome(page)
 
     // The route announcer live region is present but empty on initial load —
     // a real page load announces itself, so announcing again would be noise.
-    const announcer = page.getByTestId('route-announcer')
-    await expect(announcer).toHaveText('')
+    await expect(announcer(page)).toHaveText('')
 
     // Client-side navigate to a known public RFD from the index
     await page.getByPlaceholder('Filter by').fill('Partnership as Shared Values')
     await page.getByRole('link', { name: 'Partnership as Shared Values' }).click()
     await expectRfdPage(page, 'Partnership as Shared Values', 'Bryan Cantrill')
 
-    // The new page title is announced to screen readers...
-    await expect(announcer).toHaveText('68 - Partnership as Shared Values | RFD | Oxide')
+    // The new page is announced, with the title's pipes turned into commas so a
+    // screen reader reads it as a phrase rather than reading the punctuation.
+    await expect(announcer(page)).toHaveText(
+      '68 - Partnership as Shared Values, RFD, Oxide',
+    )
 
-    // ...and focus, dropped on <body> when the clicked link unmounted, is
-    // moved to the content wrapper so the reading position starts at the top
-    // of the new page, like a real page load.
-    await expect(page.locator('.root')).toBeFocused()
+    // Focus goes to the new page's h1, not the <main> wrapper: VoiceOver reads
+    // a focused heading, and unlike <main> the h1 remounts on every nav, so
+    // focusing it always fires an event and moves the VO cursor.
+    await expect(page.getByRole('heading', { level: 1 })).toBeFocused()
 
     // Navigating back to the index announces again, but does not steal focus:
-    // the filter input's own autofocus wins.
+    // the filter input's own autofocus wins because it's inside #content.
     await page.getByRole('link', { name: 'Back to index' }).click()
-    await expect(announcer).toHaveText('RFD | Oxide')
+    await expect(announcer(page)).toHaveText('RFD, Oxide')
     await expect(page.getByPlaceholder('Filter by')).toBeFocused()
+  })
+
+  test('focusing the heading does not clobber restored scroll', async ({ page }) => {
+    await page.goto('/rfd/0068')
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+
+    await page.evaluate(() => window.scrollTo(0, 1500))
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(1000)
+
+    await page.getByRole('link', { name: 'Back to index' }).click()
+    await expect(page.getByPlaceholder('Filter by')).toBeFocused()
+
+    // Going back restores the scroll position, and the announcer's focus() uses
+    // preventScroll so it doesn't yank us to the top of the page.
+    await page.goBack()
+    await expect(page.getByRole('heading', { level: 1 })).toBeFocused()
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(1000)
   })
 })
 
@@ -437,6 +465,16 @@ test.describe('Skip link and landmarks', () => {
 
     // the filter input steals autofocus on the homepage, so focus the skip
     // link directly rather than tabbing to it
+    const skipLink = page.getByRole('link', { name: 'Skip to content' })
+    await skipLink.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('main')).toBeFocused()
+  })
+
+  test('login page has a main landmark and working skip link', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible()
+
     const skipLink = page.getByRole('link', { name: 'Skip to content' })
     await skipLink.focus()
     await page.keyboard.press('Enter')

--- a/test/e2e/everything.spec.ts
+++ b/test/e2e/everything.spec.ts
@@ -419,7 +419,7 @@ test.describe('Accessible client-side navigation', () => {
     await expect(page.getByRole('heading', { level: 1 })).toBeFocused()
 
     // Navigating back to the index announces again, but does not steal focus:
-    // the filter input's own autofocus wins because it's inside #content.
+    // the index page focuses its own filter input and we stay out of its way.
     await page.getByRole('link', { name: 'Back to index' }).click()
     await expect(announcer(page)).toHaveText('RFD, Oxide')
     await expect(page.getByPlaceholder('Filter by')).toBeFocused()


### PR DESCRIPTION
Prompted by [feedback](https://news.ycombinator.com/item?id=49318814) that RFD links here don't work with screen readers. Next.js includes a route announcer for this; React Router leaves it to the app, so here we add one.

## 🤖 summary

* After each client-side navigation, a visually hidden `aria-live` region announces the new `document.title`. Nothing is announced on initial load, since a real page load announces itself. Same approach as Next.js's built-in announcer:

  https://github.com/vercel/next.js/blob/08b1916/packages/next/src/client/route-announcer.tsx

* If navigation dropped focus on `<body>`, focus moves to a `tabIndex={-1}` content wrapper so the reading position starts at the top of the new page, like a real page load. Routes that set their own focus on mount (the index page autofocuses its filter input) win, because their effects run before the announcer's. Gatsby's user testing with screen reader users recommended this announce + move-focus combination (the Next.js implementation also cites it):

  https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/

* Second commit: a "Skip to content" link, visually hidden until keyboard-focused, targeting a `<main id="content">` on the index and RFD pages. The index page's content wrapper is now a `<main>` landmark; the RFD page already had one.

New e2e tests cover the announcement, both focus behaviors (moved to content after navigating to an RFD, left alone on the filter input after navigating home), and the skip link being first in tab order.