### PR TITLE
Upgrade `@oxide/react-asciidoc` and `@oxide/design-system`

### DIFF
--- a/app/components/AsciidocBlocks/Footnote.tsx
+++ b/app/components/AsciidocBlocks/Footnote.tsx
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import {
+  Context,
+  inlineHtml,
+  parse,
+  useConverterContext,
+  type Inline,
+} from '@oxide/react-asciidoc'
+import { type ReactNode } from 'react'
+
+import { useHoverCard } from '~/components/rfd/use-hover-card'
+
+/**
+ * Footnote inline override. Keeps the stock `[n]` superscript marker, but shows
+ * the footnote body in a hover card so it can be read — and its inner links
+ * clicked — without scrolling down to the footnotes section.
+ */
+const Footnote = ({
+  node,
+  children,
+}: {
+  node: Inline.FootnoteNode
+  children: ReactNode
+}) => {
+  // The body (`children`) is already rendered with our inline overrides, so RFD
+  // links inside a footnote keep their own previews. It renders in the card,
+  // which lives outside the <Asciidoc> tree — re-provide the converter context
+  // so those nested overrides don't lose it.
+  const ctx = useConverterContext()
+  const hasBody = (node.text?.length ?? 0) > 0
+
+  const { ref, onMouseEnter, onMouseLeave } = useHoverCard<HTMLSpanElement>(() =>
+    hasBody
+      ? {
+          key: `footnote-${node.index ?? node.id ?? ''}`,
+          content: (
+            // `footnotes` + the same text container the footnotes section uses,
+            // so links / code / text inherit the identical treatment.
+            <Context.Provider value={ctx}>
+              <div className="footnotes text-sans-md text-default">
+                <p className="m-0">{children}</p>
+              </div>
+            </Context.Provider>
+          ),
+        }
+      : null,
+  )
+
+  // Stock marker (`<sup class="footnote">[n]</sup>`) — round-tripped so it stays
+  // identical to the default renderer.
+  const marker = parse(inlineHtml([node]).__html)
+  if (!hasBody) return <>{marker}</>
+
+  return (
+    <span
+      ref={ref}
+      className="[&_a]:target-2"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {marker}
+    </span>
+  )
+}
+
+export default Footnote

--- a/app/components/AsciidocBlocks/Footnotes.tsx
+++ b/app/components/AsciidocBlocks/Footnotes.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { type DocumentBlock } from '@oxide/react-asciidoc'
+import { RenderInline, type DocumentBlock } from '@oxide/react-asciidoc'
 import { Link } from 'react-router'
 
 import Container from '../Container'
@@ -32,19 +32,18 @@ const Footnotes = ({ doc }: { doc: DocumentBlock }) => {
                 id={`_footnotedef_${footnote.index}`}
                 className="max-800:flex relative mb-2 items-baseline"
               >
-                <div className="text-mono-xs text-tertiary 800:absolute 800:top-0.5 800:-left-12 800:text-right w-6 shrink-0 rounded-full tracking-normal!">
+                <div className="text-mono-xs text-tertiary 800:absolute 800:top-px 800:-left-12 800:text-right w-6 shrink-0 rounded-full tracking-normal!">
                   {footnote.index}
                 </div>
                 <div className="text-sans-md text-default max-w-200">
-                  <p
-                    dangerouslySetInnerHTML={{ __html: footnote.text || '' }}
-                    className="inline"
-                  />{' '}
+                  <p className="inline">
+                    <RenderInline nodes={footnote.textInlines} />
+                  </p>
                   <Link
                     className="footnote group text-accent-tertiary group-hover:text-accent -m-2 p-2 whitespace-nowrap"
                     to={`#_footnoteref_${footnote.index}`}
                   >
-                    <GotoIcon className="inline-block rotate-180" />
+                    <GotoIcon className="ml-1 inline-block rotate-180" />
                     <span className="inline-block translate-x-0 opacity-0 transition-all group-hover:translate-x-1 group-hover:opacity-100">
                       View
                     </span>

--- a/app/components/AsciidocBlocks/Image.tsx
+++ b/app/components/AsciidocBlocks/Image.tsx
@@ -7,51 +7,34 @@
  */
 
 import * as Ariakit from '@ariakit/react'
-import { type Block, type Inline } from '@asciidoctor/core'
-import { Title, useConverterContext, type ImageBlock } from '@oxide/react-asciidoc'
+import {
+  Title,
+  useConverterContext,
+  type ImageBlock,
+  type Inline,
+} from '@oxide/react-asciidoc'
 import { useState } from 'react'
 
-function nodeIsInline(node: Block | Inline): node is Inline {
-  return node.isInline()
-}
+const InlineImage = ({ node }: { node: Inline.ImageNode }) => {
+  const { document } = useConverterContext()
+  const docAttrs = document.attributes || {}
 
-const InlineImage = ({ node }: { node: Block | Inline }) => {
-  const documentAttrs = node.getDocument().getAttributes()
+  const url = `/rfd/image/${docAttrs.rfdnumber}/${node.target}`
 
-  const target = nodeIsInline(node)
-    ? node.getTarget() || '' // Getting target on inline nodes
-    : node.getAttribute('target') // Getting target on block nodes
+  let img = <img src={url} alt={node.alt} width={node.width} height={node.height} />
 
-  const uri = node.getImageUri(target)
-  const url = `/rfd/image/${documentAttrs.rfdnumber}/${uri}`
-
-  let img = (
-    <img
-      src={url}
-      alt={node.getAttribute('alt')}
-      width={node.getAttribute('width')}
-      height={node.getAttribute('height')}
-    />
-  )
-
-  if (node.hasAttribute('link')) {
+  if (node.link) {
     img = (
-      <a className="image" href={node.getAttribute('link')}>
+      <a className="image" href={node.link}>
         {img}
       </a>
     )
   }
 
   return (
-    <div
-      className={`image ${
-        node.hasAttribute('align') ? 'text-' + node.getAttribute('align') : ''
-      } ${node.hasAttribute('float') ? node.getAttribute('float') : ''} ${
-        node.getRole() ? node.getRole() : ''
-      }`}
-    >
+    <span className={`image ${node.float ? node.float : ''} ${node.role ? node.role : ''}`}>
       {img}
-    </div>
+    </span>
   )
 }
 

--- a/app/components/AsciidocBlocks/RfdLink.tsx
+++ b/app/components/AsciidocBlocks/RfdLink.tsx
@@ -1,0 +1,257 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import {
+  Context,
+  inlineHtml,
+  parse,
+  RenderInline,
+  useConverterContext,
+  type Inline,
+} from '@oxide/react-asciidoc'
+import cn from 'classnames'
+import { isValidElement, type ReactNode } from 'react'
+import { Link, useRouteLoaderData } from 'react-router'
+
+import Icon from '~/components/Icon'
+import { extractRfdNumber, RfdPreviewCard } from '~/components/rfd/RfdPreview'
+import { useHoverCard } from '~/components/rfd/use-hover-card'
+import type { RfdListItem } from '~/services/rfd.server'
+
+type AnchorProps = {
+  href?: string
+  id?: string
+  className?: string
+  target?: string
+}
+
+/**
+ * Inline override for anchors. RFDs referenced from the body — whether as a
+ * link, a `[bibliography]` cross-reference resolving to an RFD URL, or a classic
+ * `<<rfd-123>>` anchor — become relative react-router `<Link>`s with a hover
+ * preview. Other internal links navigate client-side, bibliography xrefs to
+ * external resources link straight out, and everything else (in-page xrefs,
+ * refs, external links) renders exactly as the default renderer would — we
+ * round-trip the node through `inlineHtml`/`parse` so there's no drift from
+ * stock output.
+ */
+const RfdLink = ({ node, children }: { node: Inline.AnchorNode; children: ReactNode }) => {
+  const parsed = parse(inlineHtml([node]).__html)
+  // Bibrefs serialise to multiple nodes (`[<a/>]`); anything that isn't a
+  // single anchor element just renders stock.
+  const props = isValidElement(parsed) ? (parsed.props as AnchorProps) : null
+
+  // A bibliography xref carries its resolved URL on `externalHref`; it takes
+  // priority over the stock in-page (`#id`) anchor href.
+  const externalHref = node.subtype === 'xref' ? node.externalHref : undefined
+
+  // The resolved bibliography entry's content, when an xref points at one.
+  // Added upstream alongside `externalHref`; until it lands this is never set,
+  // so the reference-card branch below is simply a no-op.
+  const referenceInlines =
+    node.subtype === 'xref'
+      ? (node as Inline.AnchorNode & { referenceInlines?: Inline.InlineNode[] })
+          .referenceInlines
+      : undefined
+
+  // The target used to detect RFD references: a link's decoded href, a
+  // bibliography xref's resolved URL, or a classic `<<rfd-123>>`'s `#` anchor.
+  const navHref = externalHref ?? props?.href
+
+  const rfdNumber = navHref ? extractRfdNumber(navHref) : null
+  if (rfdNumber !== null) {
+    return (
+      <RfdHoverLink rfdNumber={rfdNumber} id={props?.id} className={props?.className}>
+        {children}
+      </RfdHoverLink>
+    )
+  }
+
+  // Bibliography cross-reference: read the entry in a hover card without
+  // scrolling to the references section. Clicking still follows the citation —
+  // an external URL, or the stock in-page `#id` anchor.
+  if (referenceInlines?.length) {
+    return (
+      <RfdReferenceLink
+        href={externalHref ?? props?.href}
+        external={!!externalHref}
+        id={props?.id}
+        className={props?.className}
+        nodes={referenceInlines}
+      >
+        {children}
+      </RfdReferenceLink>
+    )
+  }
+
+  // Bibliography xref to a non-RFD external resource links straight out.
+  if (externalHref) {
+    return (
+      <a
+        href={externalHref}
+        target="_blank"
+        rel="noopener"
+        id={props?.id}
+        className={props?.className}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  // Same-origin relative links navigate client-side. Absolute URLs (including
+  // in-page `#` anchors and `target="_blank"` links) keep the stock anchor.
+  if (node.subtype === 'link' && props?.href?.startsWith('/') && !props.target) {
+    return (
+      <Link to={props.href} id={props.id} className={props.className} prefetch="intent">
+        {children}
+      </Link>
+    )
+  }
+
+  return <>{parsed}</>
+}
+
+/**
+ * A `[bibliography]` cross-reference. Clicking follows the citation (an external
+ * URL, or the stock in-page anchor); hovering shows the entry's content in a
+ * card so it can be read — and its links clicked — without scrolling down.
+ */
+const RfdReferenceLink = ({
+  href,
+  external,
+  id,
+  className,
+  nodes,
+  children,
+}: {
+  external: boolean
+  nodes: Inline.InlineNode[]
+  children: ReactNode
+} & AnchorProps) => {
+  // The card renders outside the <Asciidoc> tree, so re-provide the converter
+  // context — that keeps the entry's inner links flowing through our overrides,
+  // and `.footnotes` gives it the footnotes-section styling.
+  const ctx = useConverterContext()
+
+  const { ref, onMouseEnter, onMouseLeave, onClick } = useHoverCard<HTMLAnchorElement>(
+    () => ({
+      key: `ref-${href ?? ''}`,
+      content: (
+        <Context.Provider value={ctx}>
+          <div className="footnotes text-sans-md text-default">
+            <p className="m-0">
+              <RenderInline nodes={nodes} />
+            </p>
+          </div>
+        </Context.Provider>
+      ),
+    }),
+  )
+
+  return (
+    <a
+      ref={ref}
+      href={href}
+      id={id}
+      className={className}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener' : undefined}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      {children}
+    </a>
+  )
+}
+
+/**
+ * A link to another RFD: navigates client-side and opens a hover preview after
+ * a short delay. The delay and cleanup live in this component, so there's no
+ * document-wide event delegation.
+ */
+const RfdHoverLink = ({
+  rfdNumber,
+  id,
+  className,
+  children,
+}: {
+  rfdNumber: number
+  children: ReactNode
+} & AnchorProps) => {
+  // Read the root loader directly rather than importing `useRootLoaderData`:
+  // this component sits in the server-side asciidoctor import chain, and
+  // importing `~/root` there would create a circular import.
+  const data = useRouteLoaderData('root') as
+    | { rfds: RfdListItem[]; user: unknown }
+    | undefined
+  const rfds = data?.rfds ?? []
+  const { document } = useConverterContext()
+  const currentRfd = Number(document.attributes?.rfdnumber)
+  const matchedRfd = rfds.find((rfd) => rfd.number === rfdNumber)
+
+  const { ref, onMouseEnter, onMouseLeave, onClick } = useHoverCard<HTMLAnchorElement>(
+    () =>
+      matchedRfd && rfdNumber !== currentRfd
+        ? { key: `rfd-${rfdNumber}`, content: <RfdPreviewCard rfd={matchedRfd} /> }
+        : null,
+  )
+
+  // The linked RFD isn't in the set this reader can see. We can't (and
+  // shouldn't) tell "private" apart from "doesn't exist" — that mirrors the RFD
+  // loader, which deliberately 404s rather than leak a private RFD's existence.
+  // Surface it as a restricted reference instead of a link that dead-ends.
+  if (!matchedRfd && rfdNumber !== currentRfd) {
+    const formattedNumber = rfdNumber.toString().padStart(4, '0')
+    const lock = (
+      <Icon
+        name="security"
+        size={16}
+        className="text-tertiary align-text-center ml-0.5 inline-block h-3 w-3"
+      />
+    )
+    // Signed-out readers can gain access by logging in, so point them there;
+    // signed-in readers simply don't have access, so it's non-interactive.
+    return data?.user ? (
+      <span
+        className={cn(className, 'text-tertiary cursor-default')}
+        title="You don't have access to this RFD"
+      >
+        {children}
+        {lock}
+      </span>
+    ) : (
+      <Link
+        to={`/login?returnTo=/rfd/${formattedNumber}`}
+        className={cn(className, 'text-tertiary')}
+        title="Sign in to view this RFD"
+      >
+        {children}
+        {lock}
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      ref={ref}
+      to={`/rfd/${rfdNumber.toString().padStart(4, '0')}`}
+      id={id}
+      className={className}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+      prefetch="intent"
+    >
+      {children}
+    </Link>
+  )
+}
+
+export default RfdLink

--- a/app/components/AsciidocBlocks/index.ts
+++ b/app/components/AsciidocBlocks/index.ts
@@ -9,6 +9,8 @@
 import { AsciiDocBlocks } from '@oxide/design-system/asciidoc'
 import { type Options } from '@oxide/react-asciidoc'
 
+import { inlineOverrides } from '~/utils/asciidoctor'
+
 import { CustomDocument } from './Document'
 import { Image } from './Image'
 import Listing from './Listing'
@@ -21,5 +23,6 @@ export const opts: Options = {
     section: AsciiDocBlocks.Section,
     listing: Listing,
   },
+  inlineOverrides,
   customDocument: CustomDocument,
 }

--- a/app/components/rfd/RfdPreview.tsx
+++ b/app/components/rfd/RfdPreview.tsx
@@ -9,11 +9,12 @@
 import cn from 'classnames'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useNavigation } from 'react-router'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { Fragment, useEffect, useRef } from 'react'
+import { Link } from 'react-router'
 
-import { useRootLoaderData } from '~/root'
 import type { RfdListItem } from '~/services/rfd.server'
+import { closeHoverCard, useHoverCardStore } from '~/stores/hover-card'
 
 dayjs.extend(relativeTime)
 
@@ -54,208 +55,13 @@ export function calcOffset(element: HTMLAnchorElement | HTMLElement) {
   return { left: x, top: y }
 }
 
-interface RfdPreviewState {
-  sourceRfd: number
-  rfd: RfdListItem
-  position: { left: number; top: number }
-  anchor: HTMLAnchorElement
-}
-
-interface RfdPreviewProps {
-  currentRfd: number
-  nodeRef: React.RefObject<HTMLElement | null>
-}
-
-const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
-  const navigate = useNavigate()
-  const navigation = useNavigation()
-  const isNavigating = navigation.state !== 'idle'
-  const { rfds } = useRootLoaderData()
-  const [preview, setPreview] = useState<RfdPreviewState | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const previewRef = useRef<HTMLDivElement>(null)
-
-  const clearHoverTimeout = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = null
-    }
-  }, [])
-
-  const activePreview = preview?.sourceRfd === currentRfd ? preview : null
-
-  // Based on https://github.com/remix-run/react-router-website/blob/main/app/ui/delegate-markdown-links.ts
-  // Converts regular AsciiDoc a tags and makes them React Routery
-  useEffect(() => {
-    const node = nodeRef.current
-    if (!node) return
-
-    const handleClick = (event: MouseEvent) => {
-      if (!(event.target instanceof HTMLElement)) return
-
-      const a = event.target.closest('a')
-
-      if (
-        a && // is anchor or has anchor parent
-        a.hasAttribute('href') && // has an href
-        a.host === window.location.host && // is internal
-        event.button === 0 && // left click
-        (!a.target || a.target === '_self') && // Let browser handle "target=_blank" etc.
-        !(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) // not modified
-      ) {
-        const rfdNum = extractRfdNumber(a.getAttribute('href') || '')
-
-        if (rfdNum !== null) {
-          event.preventDefault()
-          clearHoverTimeout()
-          setPreview(null)
-          const formattedNumber = rfdNum.toString().padStart(4, '0')
-          navigate(`/rfd/${formattedNumber}`)
-          return
-        }
-
-        if (a.host === window.location.host) {
-          event.preventDefault()
-          const { pathname, search, hash } = a
-          navigate({ pathname, search, hash })
-        }
-      }
-    }
-
-    const handleMouseOver = (event: MouseEvent) => {
-      if (isNavigating) return
-      if (!(event.target instanceof HTMLElement)) return
-
-      const anchor = event.target.closest('a')
-      if (!anchor) return
-
-      const rfdNum = extractRfdNumber(anchor.getAttribute('href') || '')
-
-      if (rfdNum === null || rfdNum === currentRfd) return
-
-      const matchedRfd = rfds.find((rfd) => rfd.number === rfdNum)
-      if (!matchedRfd) return
-
-      if (timeoutRef.current) return
-
-      timeoutRef.current = setTimeout(() => {
-        const offset = calcOffset(anchor)
-        setPreview({
-          sourceRfd: currentRfd,
-          rfd: matchedRfd,
-          position: offset,
-          anchor,
-        })
-        timeoutRef.current = null
-      }, 125)
-    }
-
-    const handleMouseOut = (event: MouseEvent) => {
-      if (!(event.target instanceof HTMLElement)) return
-
-      const anchor = event.target.closest('a')
-      if (anchor) {
-        clearHoverTimeout()
-      }
-    }
-
-    node.addEventListener('click', handleClick)
-    node.addEventListener('mouseover', handleMouseOver)
-    node.addEventListener('mouseout', handleMouseOut)
-
-    return () => {
-      node.removeEventListener('click', handleClick)
-      node.removeEventListener('mouseover', handleMouseOver)
-      node.removeEventListener('mouseout', handleMouseOut)
-      clearHoverTimeout()
-    }
-  }, [navigate, nodeRef, currentRfd, rfds, clearHoverTimeout, isNavigating])
-
-  useEffect(() => {
-    if (!activePreview) return
-
-    type Point = [number, number]
-    type Polygon = Point[]
-
-    // 1┌────────────┐2
-    //  └────────────┘\
-    //  |              \
-    //  ┌───────────────┐3
-    //  │               │
-    // 5└───────────────┘4
-    //
-    // Returns a set of points for each corner of a polygon
-    // that the cursor can safely be within without closing
-    // the floating preview. Plus a buffer of 10px to avoid
-    // it being too sensitive
-    const getPolygon = (anchorRect: DOMRect, floatingRect: DOMRect): Polygon => {
-      const buffer = 10
-      const p1: Point = [anchorRect.left - buffer, anchorRect.top - buffer]
-      const p2: Point = [
-        anchorRect.left + anchorRect.width + buffer,
-        anchorRect.top + anchorRect.height - buffer,
-      ]
-      const p3: Point = [
-        floatingRect.left + floatingRect.width + buffer,
-        floatingRect.top - buffer,
-      ]
-      const p4: Point = [
-        floatingRect.left + floatingRect.width + buffer,
-        floatingRect.top + floatingRect.height + buffer,
-      ]
-      const p5: Point = [
-        floatingRect.left - buffer,
-        floatingRect.top + floatingRect.height + buffer,
-      ]
-      return [p1, p2, p3, p4, p5]
-    }
-
-    const isPointInPolygon = (point: Point, polygon: Polygon) => {
-      const [x, y] = point
-      let isInside = false
-      const length = polygon.length
-      for (let i = 0, j = length - 1; i < length; j = i++) {
-        const [xi, yi] = polygon[i] || [0, 0]
-        const [xj, yj] = polygon[j] || [0, 0]
-        const intersect =
-          yi >= y !== yj >= y && x <= ((xj - xi) * (y - yi)) / (yj - yi) + xi
-        if (intersect) {
-          isInside = !isInside
-        }
-      }
-      return isInside
-    }
-
-    const handleMouseMove = (event: MouseEvent) => {
-      if (!previewRef.current) return
-
-      const cursor: Point = [event.clientX, event.clientY]
-      const floatingRect = previewRef.current.getBoundingClientRect()
-      const anchorRect = activePreview.anchor.getBoundingClientRect()
-
-      const polygon = getPolygon(anchorRect, floatingRect)
-      const isInside = isPointInPolygon(cursor, polygon)
-
-      if (!isInside) {
-        setPreview(null)
-      }
-    }
-
-    window.addEventListener('mousemove', handleMouseMove)
-    return () => window.removeEventListener('mousemove', handleMouseMove)
-  }, [activePreview])
-
-  if (!activePreview) return null
-
-  const { title, number, state, latestMajorChangeAt, formattedNumber } = activePreview.rfd
-  const authors = activePreview.rfd.authors || []
+/** The body of the hover card for an RFD link: number, title, authors, state. */
+export const RfdPreviewCard = ({ rfd }: { rfd: RfdListItem }) => {
+  const { title, number, state, latestMajorChangeAt, formattedNumber } = rfd
+  const authors = rfd.authors || []
 
   return (
-    <div
-      ref={previewRef}
-      className="shadow-tooltip bg-raise absolute z-10 mt-8 flex w-[24rem] rounded-lg p-3"
-      style={{ top: activePreview.position.top, left: activePreview.position.left }}
-    >
+    <div className="flex w-[22rem]">
       <Link
         prefetch="intent"
         to={`/rfd/${formattedNumber}`}
@@ -297,4 +103,126 @@ const RfdPreview = ({ currentRfd, nodeRef }: RfdPreviewProps) => {
   )
 }
 
-export default RfdPreview
+const EASE_OUT = [0.165, 0.84, 0.44, 1] as const
+
+/**
+ * The single floating hover card. It renders whatever a trigger (RFD link,
+ * footnote, …) put in the store, positioned under that trigger, and closes when
+ * the cursor leaves the safe polygon between the trigger and the card.
+ */
+const HoverCard = ({ currentRfd }: { currentRfd: number }) => {
+  const card = useHoverCardStore((state) => state.card)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const reduceMotion = useReducedMotion()
+
+  // Dismiss any open card when navigating to a different RFD
+  useEffect(() => closeHoverCard, [currentRfd])
+
+  useEffect(() => {
+    if (!card) return
+
+    type Point = [number, number]
+    type Polygon = Point[]
+
+    // 1┌────────────┐2
+    //  └────────────┘\
+    //  |              \
+    //  ┌───────────────┐3
+    //  │               │
+    // 5└───────────────┘4
+    //
+    // Returns a set of points for each corner of a polygon
+    // that the cursor can safely be within without closing
+    // the floating card. Plus a buffer of 10px to avoid
+    // it being too sensitive
+    const getPolygon = (anchorRect: DOMRect, floatingRect: DOMRect): Polygon => {
+      const buffer = 10
+      const p1: Point = [anchorRect.left - buffer, anchorRect.top - buffer]
+      const p2: Point = [
+        anchorRect.left + anchorRect.width + buffer,
+        anchorRect.top + anchorRect.height - buffer,
+      ]
+      const p3: Point = [
+        floatingRect.left + floatingRect.width + buffer,
+        floatingRect.top - buffer,
+      ]
+      const p4: Point = [
+        floatingRect.left + floatingRect.width + buffer,
+        floatingRect.top + floatingRect.height + buffer,
+      ]
+      const p5: Point = [
+        floatingRect.left - buffer,
+        floatingRect.top + floatingRect.height + buffer,
+      ]
+      return [p1, p2, p3, p4, p5]
+    }
+
+    const isPointInPolygon = (point: Point, polygon: Polygon) => {
+      const [x, y] = point
+      let isInside = false
+      const length = polygon.length
+      for (let i = 0, j = length - 1; i < length; j = i++) {
+        const [xi, yi] = polygon[i] || [0, 0]
+        const [xj, yj] = polygon[j] || [0, 0]
+        const intersect =
+          yi >= y !== yj >= y && x <= ((xj - xi) * (y - yi)) / (yj - yi) + xi
+        if (intersect) {
+          isInside = !isInside
+        }
+      }
+      return isInside
+    }
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!cardRef.current) return
+
+      const cursor: Point = [event.clientX, event.clientY]
+      const floatingRect = cardRef.current.getBoundingClientRect()
+      const anchorRect = card.anchor.getBoundingClientRect()
+
+      const polygon = getPolygon(anchorRect, floatingRect)
+      const isInside = isPointInPolygon(cursor, polygon)
+
+      if (!isInside) {
+        closeHoverCard()
+      }
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    return () => window.removeEventListener('mousemove', handleMouseMove)
+  }, [card])
+
+  return (
+    card && (
+      <motion.div
+        // Re-key per target so hopping between links cross-fades rather than
+        // sliding the same card to a new position.
+        key={card.key}
+        ref={cardRef}
+        // `break-words` (inherited) wraps long, unbreakable URLs so they
+        // can't overflow past `max-w`.
+        className="shadow-tooltip bg-raise absolute z-10 mt-6 w-max max-w-[24rem] rounded-lg p-3 break-words"
+        style={{
+          top: card.position.top,
+          left: card.position.left,
+          // Grow from the anchored top-left corner (under the trigger), not center.
+          transformOrigin: 'top left',
+          willChange: 'transform, opacity',
+        }}
+        initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, y: -4 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.98, y: -4 }}
+        transition={{
+          duration: 0.18,
+          ease: EASE_OUT,
+          // Exits ~20% quicker than entrances feel right.
+          opacity: { duration: 0.14, ease: EASE_OUT },
+        }}
+      >
+        {card.content}
+      </motion.div>
+    )
+  )
+}
+
+export default HoverCard

--- a/app/components/rfd/RfdPreview.tsx
+++ b/app/components/rfd/RfdPreview.tsx
@@ -9,7 +9,7 @@
 import cn from 'classnames'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { motion, useReducedMotion } from 'motion/react'
 import { Fragment, useEffect, useRef } from 'react'
 import { Link } from 'react-router'
 

--- a/app/components/rfd/use-hover-card.ts
+++ b/app/components/rfd/use-hover-card.ts
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { useEffect, useRef, type ReactNode } from 'react'
+import { useNavigation } from 'react-router'
+
+import { calcOffset } from '~/components/rfd/RfdPreview'
+import { closeHoverCard, openHoverCard } from '~/stores/hover-card'
+
+const HOVER_DELAY = 125
+
+/**
+ * Hover-intent wiring for an inline element (an RFD link, a footnote marker,
+ * …) that opens a floating hover card after a short delay. `getCard` runs on
+ * hover-in and returns the card's identity + body, or `null` to suppress it.
+ * Returns a ref to put on the trigger plus the handlers to spread onto it, so
+ * each trigger owns its hover state — no document-wide event delegation.
+ */
+export function useHoverCard<T extends HTMLElement>(
+  getCard: () => { key: string; content: ReactNode } | null,
+) {
+  const ref = useRef<T>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const navigation = useNavigation()
+
+  const clearHoverTimeout = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }
+
+  useEffect(() => clearHoverTimeout, [])
+
+  const onMouseEnter = () => {
+    if (navigation.state !== 'idle' || timeoutRef.current) return
+
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null
+      const anchor = ref.current
+      const card = anchor && getCard()
+      if (anchor && card) {
+        openHoverCard({ ...card, position: calcOffset(anchor), anchor })
+      }
+    }, HOVER_DELAY)
+  }
+
+  return { ref, onMouseEnter, onMouseLeave: clearHoverTimeout, onClick: closeHoverCard }
+}

--- a/app/routes/rfd.$slug.tsx
+++ b/app/routes/rfd.$slug.tsx
@@ -24,6 +24,7 @@ import {
   useState,
 } from 'react'
 import {
+  Link,
   redirect,
   useLoaderData,
   useLocation,
@@ -225,17 +226,15 @@ export default function Rfd() {
 
   const bodyRef = useRef<HTMLDivElement>(null)
 
-  const containerRef = useRef<HTMLDivElement>(null)
-
   return (
-    <div ref={containerRef}>
+    <div>
       {/* key makes the search dialog close on selection */}
       <Header currentRfd={rfd} key={pathname + hash} />
       <main className="800:mt-16 relative mt-12 pb-20 print:mt-0">
         {inlineComments && user && pullNumber && (
           <RfdInlineComments pullNumber={pullNumber} />
         )}
-        <RfdPreview currentRfd={number} nodeRef={containerRef} />
+        <RfdPreview currentRfd={number} />
         <Container isGrid className="page-header 800:mb-16 mb-12">
           {state && (
             <div className="800:col-start-2 1200:col-start-3 flex print:hidden">
@@ -279,18 +278,18 @@ export default function Rfd() {
               <div>
                 {authors.map((author, index) => (
                   <Fragment key={author.name}>
-                    <a
+                    <Link
                       className={cn(
                         'link-with-underline inline-block',
                         !author.email && 'pointer-events-none',
                       )}
-                      href={
+                      to={
                         author.email ? `/?author=${encodeURIComponent(author.email)}` : ''
                       }
                     >
                       {author.name}
                       {index < authors.length - 1 && ', '}
-                    </a>{' '}
+                    </Link>{' '}
                   </Fragment>
                 ))}
               </div>
@@ -301,13 +300,13 @@ export default function Rfd() {
               <div>
                 {labels.map((label, index) => (
                   <Fragment key={label}>
-                    <a
+                    <Link
                       className="link-with-underline inline-block"
-                      href={`/?label=${label.trim()}`}
+                      to={`/?label=${label.trim()}`}
                     >
                       {label.trim()}
                       {index < labels.length - 1 && ', '}
-                    </a>{' '}
+                    </Link>{' '}
                   </Fragment>
                 ))}
               </div>

--- a/app/stores/hover-card.ts
+++ b/app/stores/hover-card.ts
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import type { ReactNode } from 'react'
+import { create } from 'zustand'
+
+export interface HoverCardState {
+  /** Identity for the card. Changing it cross-fades between targets rather than
+   *  sliding the same card to a new position. */
+  key: string
+  /** What to render inside the floating card. */
+  content: ReactNode
+  position: { left: number; top: number }
+  /** The element the card is anchored to — used for the safe-polygon hit test. */
+  anchor: HTMLElement
+}
+
+/**
+ * The single floating card shown on hover of an RFD link, footnote, etc.
+ * Triggers write to this store (see {@link useHoverCard}); the `HoverCard`
+ * overlay subscribes to it. A store rather than DOM delegation means each
+ * trigger manages its own hover state through ordinary React handlers.
+ */
+export const useHoverCardStore = create<{ card: HoverCardState | null }>(() => ({
+  card: null,
+}))
+
+export const openHoverCard = (card: HoverCardState) => useHoverCardStore.setState({ card })
+
+export const closeHoverCard = () => useHoverCardStore.setState({ card: null })

--- a/app/utils/asciidoctor.tsx
+++ b/app/utils/asciidoctor.tsx
@@ -5,11 +5,15 @@
  *
  * Copyright Oxide Computer Company
  */
-import { type Block, type Html5Converter } from '@asciidoctor/core'
-import { InlineConverter, loadAsciidoctor } from '@oxide/design-system/asciidoc'
-import { renderToString } from 'react-dom/server'
+import {
+  inlineOverrides as baseInlineOverrides,
+  loadAsciidoctor,
+} from '@oxide/design-system/asciidoc'
+import { type InlineOverrides } from '@oxide/react-asciidoc'
 
+import Footnote from '~/components/AsciidocBlocks/Footnote'
 import { InlineImage } from '~/components/AsciidocBlocks/Image'
+import RfdLink from '~/components/AsciidocBlocks/RfdLink'
 
 const attrs = {
   sectlinks: 'true',
@@ -19,27 +23,11 @@ const attrs = {
 
 const ad = loadAsciidoctor({})
 
-class CustomInlineConverter {
-  baseConverter: Html5Converter
-
-  constructor() {
-    this.baseConverter = new InlineConverter()
-  }
-
-  convert(node: Block, transform: string) {
-    switch (node.getNodeName()) {
-      case 'inline_image':
-        return renderToString(<InlineImage node={node} />)
-      case 'image':
-        return renderToString(<InlineImage node={node} />)
-      default:
-        break
-    }
-
-    return this.baseConverter.convert(node, transform)
-  }
+const inlineOverrides: InlineOverrides = {
+  ...baseInlineOverrides,
+  image: InlineImage,
+  anchor: RfdLink,
+  footnote: Footnote,
 }
 
-ad.ConverterFactory.register(new CustomInlineConverter(), ['html5'])
-
-export { ad, attrs }
+export { ad, attrs, inlineOverrides }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@floating-ui/react": "^0.17.0",
         "@leeoniya/ufuzzy": "^1.0.19",
         "@meilisearch/instant-meilisearch": "^0.28.0",
-        "@oxide/design-system": "^6.2.1",
-        "@oxide/react-asciidoc": "^1.3.0",
+        "@oxide/design-system": "^6.5.4",
+        "@oxide/react-asciidoc": "^2.2.0",
         "@oxide/remix-auth-rfd": "^0.1.6",
         "@oxide/rfd.ts": "^0.15.5",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -45,7 +45,6 @@
         "remeda": "^2.32.0",
         "remix-auth": "^4.2.0",
         "remix-auth-oauth2": "^3.4.1",
-        "shiki": "^3.13.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.11"
       },
@@ -2080,9 +2079,9 @@
       }
     },
     "node_modules/@oxide/design-system": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.2.1.tgz",
-      "integrity": "sha512-1QBu1CVLx20AI9QHOo/m7yFslghpYfHhHxa7r/74NV6Ff/RawkUQjl7X+NgFxLyf3jJehWgWBhcycxM+Bw1q3A==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.5.4.tgz",
+      "integrity": "sha512-mWzoqalT7leBBBEiG+afhOfywuoLb2VjykvFMBmRuI+29ykRAuaE3i70tf9wiappEnuzLbuLAYPpUYXR5wIt8Q==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
@@ -2091,11 +2090,11 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "classnames": "^2.5.1",
         "prettier-plugin-tailwindcss": "^0.6.14",
-        "shiki": "^3.13.0"
+        "shiki": "^4.4.3"
       },
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
-        "@oxide/react-asciidoc": "^1.3.0",
+        "@oxide/react-asciidoc": "^2.1.1",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
@@ -2116,17 +2115,30 @@
       }
     },
     "node_modules/@oxide/react-asciidoc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@oxide/react-asciidoc/-/react-asciidoc-1.3.0.tgz",
-      "integrity": "sha512-0QNKE03z3nh82AjmJD7Gx7uxpEa0Io4bb/3Zlqh7b87c6iyQ99nV1bdiIel/Ja7FfSdC/qqIfmcedxutvKuD7Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@oxide/react-asciidoc/-/react-asciidoc-2.2.0.tgz",
+      "integrity": "sha512-WDzRXbHTmNVYhcystt0wPeV+SkIdaXULhbxNWJWbxE8tMz1WHAzg1HcRuhwuuGazKyq3baz2fK1jiHa8WG5iZA==",
       "license": "MPL 2.0",
       "dependencies": {
+        "entities": "^6.0.1",
         "html-react-parser": "^5.2.6"
       },
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@oxide/react-asciidoc/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/@oxide/remix-auth-rfd": {
@@ -3365,64 +3377,97 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -4172,9 +4217,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -4604,9 +4649,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
     "node_modules/@upsetjs/venn.js": {
@@ -10924,9 +10969,9 @@
       }
     },
     "node_modules/property-information": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
-      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11694,19 +11739,22 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@floating-ui/react": "^0.17.0",
     "@leeoniya/ufuzzy": "^1.0.19",
     "@meilisearch/instant-meilisearch": "^0.28.0",
-    "@oxide/design-system": "^6.2.1",
-    "@oxide/react-asciidoc": "^1.3.0",
+    "@oxide/design-system": "^6.5.4",
+    "@oxide/react-asciidoc": "^2.2.0",
     "@oxide/remix-auth-rfd": "^0.1.6",
     "@oxide/rfd.ts": "^0.15.5",
     "@radix-ui/react-accordion": "^1.2.12",
@@ -56,7 +56,6 @@
     "remeda": "^2.32.0",
     "remix-auth": "^4.2.0",
     "remix-auth-oauth2": "^3.4.1",
-    "shiki": "^3.13.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.11"
   },


### PR DESCRIPTION
Upgrades `@oxide/design-system` (6.2.1 → 6.5.3) and `@oxide/react-asciidoc` (1.3.0 → 2.2.0).

- Replace the `CustomInlineConverter` class (removed in 2.x) with the new declarative `inlineOverrides` map in `app/utils/asciidoctor.tsx`, spread over the design system's base overrides.
- `InlineImage` now takes a structured `Inline.ImageNode` and reads document attributes from `useConverterContext()` instead of walking Asciidoctor AST nodes.
- Footnotes section renders via `<RenderInline nodes={footnote.textInlines} />` instead of `dangerouslySetInnerHTML`.

---

Also pulls in the hover card pattern from the docs but here:

- RFD link hover card, inline RFD cross-links (`RfdLink`) show a preview card on hover.
- Footnote hover card, footnote markers show the footnote body on hover, so it can be read without jumping to the footnotes section.
